### PR TITLE
Improve U-Plane forwarding efficiency in v1-U

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,18 @@ Package gtp provides simple and painless handling of GTP(GPRS Tunneling Protocol
 
 ### Prerequisites
 
-The following packages should be installed before starting.
+The following packages should be installed before starting.  
 
 ```shell-session
 go get -u github.com/pkg/errors
 go get -u github.com/google/go-cmp/cmp
 go get -u github.com/pascaldekloe/goe/verify
+```
+
+If you use Go 1.11+, you can also use Go Modules.
+
+```shell-session
+GO111MODULE=on go [test | build | run | etc...]
 ```
 
 ### Running examples
@@ -60,6 +66,8 @@ Examples works as it is by `go build` and executing commands in the following wa
 
 5. You will see the nodes exchanging Create Session and Modify Bearer on C-Plane, and ICMP Echo on U-Plane afterwards.
 
+_If you want to see fewer number of subscribers, please comment-out the `v2.Subscriber` definitions in `example/mme/main.go`._
+
 ### Developing by your own
 
 Each version has `net.PacketConn`-like APIs and GTP-specific ones which is often version-specific.
@@ -71,11 +79,11 @@ The basic idea behind the current implementation is;
 
 For the detailed usage of specific version, see README.md under each version's directory.
 
-| Version | Details                       |
-|---------|-------------------------------|
-| GTPv0   | [README.md](gtp/v0/README.md) |
-| GTPv1   | [README.md](gtp/v1/README.md) |
-| GTPv2   | [README.md](gtp/v2/README.md) |
+| Version | Details                   |
+| ------- | ------------------------- |
+| GTPv0   | [README.md](v0/README.md) |
+| GTPv1   | [README.md](v1/README.md) |
+| GTPv2   | [README.md](v2/README.md) |
 
 ## Supported Features
 
@@ -84,12 +92,12 @@ In other words, even if a message/IE is not marked as "Yes", you can make it wor
 
 Your contribution is welcome to implement helpers for all the types, of course!
 
-| Version           | Messages | IEs   | Networking (state machine)                           | Details                                                   |
-|-------------------|----------|-------|------------------------------------------------------|-----------------------------------------------------------|
-| GTPv0             | 35.7%    | 81.8% | not implemented yet                                  | [Supported Features](gtp/v0/README.md#supported-features) |
-| GTPv1             | 26.6%    | 30.1% | v1-U is functional, <br> v1-C is not implemented yet | [Supported Features](gtp/v1/README.md#supported-features) |
-| GTPv2             | 32.0%    | 43.2% | almost functional                                    | [Supported Features](gtp/v2/README.md#supported-features) |
-| GTP' <br> (Prime) | N/A      | N/A   | N/A                                                  | _not planned_                                             |
+| Version           | Messages | IEs   | Networking (state machine)                           | Details                                               |
+| ----------------- | -------- | ----- | ---------------------------------------------------- | ----------------------------------------------------- |
+| GTPv0             | 35.7%    | 81.8% | not implemented yet                                  | [Supported Features](v0/README.md#supported-features) |
+| GTPv1             | 26.6%    | 30.1% | v1-U is functional, <br> v1-C is not implemented yet | [Supported Features](v1/README.md#supported-features) |
+| GTPv2             | 32.0%    | 43.2% | almost functional                                    | [Supported Features](v2/README.md#supported-features) |
+| GTP' <br> (Prime) | N/A      | N/A   | N/A                                                  | _not planned_                                         |
 
 ## Disclaimer
 

--- a/examples/pgw/pgw.go
+++ b/examples/pgw/pgw.go
@@ -176,13 +176,13 @@ func handleCreateSessionRequest(c *v2.Conn, sgwAddr net.Addr, msg messages.Messa
 			}
 
 			rsp := make([]byte, n)
-			// swap IP
-			copy(rsp[12:16], buf[16:20])
-			copy(rsp[16:20], buf[12:16])
 			// update message type and checksum
 			copy(rsp, buf[:n])
 			rsp[20] = 0
 			rsp[22] = 0x9b
+			// swap IP
+			copy(rsp[12:16], buf[16:20])
+			copy(rsp[16:20], buf[12:16])
 
 			if _, err := uConn.WriteToGTP(teidOut, rsp, raddr); err != nil {
 				return

--- a/examples/sgw/main.go
+++ b/examples/sgw/main.go
@@ -48,6 +48,9 @@ var (
 	delCh    = make(chan struct{})
 	loggerCh = make(chan string)
 	errCh    = make(chan error)
+	s5cConn  *v2.Conn
+	s1uConn  *v1.UPlaneConn
+	s5uConn  *v1.UPlaneConn
 )
 
 func main() {
@@ -84,18 +87,14 @@ func main() {
 
 	// let relay start working here.
 	// this just drops packets until TEID and peer information is registered.
-	s1uConn, err := v1.ListenAndServeUPlane(s1uladdr, 0, errCh)
+	s1uConn, err = v1.ListenAndServeUPlane(s1uladdr, 0, errCh)
 	if err != nil {
 		log.Fatal(err)
 	}
-	s5uConn, err := v1.ListenAndServeUPlane(s5uladdr, 0, errCh)
+	s5uConn, err = v1.ListenAndServeUPlane(s5uladdr, 0, errCh)
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	relay = v1.NewRelay(s1uConn, s5uConn)
-	go relay.Run()
-	defer relay.Close()
 
 	// wait for events(logs, errors, timers).
 	for {

--- a/v1/README.md
+++ b/v1/README.md
@@ -62,23 +62,16 @@ if _, err := uConn.WriteToGTP(teid, payload, addr); err != nil {
 }
 ```
 
-For SGSN/S-GW-ish nodes, this package provides a special feature: `Relay`. It relays a packet coming from a `UPlaneConn` to another.
+For SGSN/S-GW-ish nodes, this package provides a method to swap TEID and forward T-PDU packets efficiently.  
+By using `*UPlaneConn.Relay()`, the connection automatically handles the T-PDU packet in background with the least cost.
 
 ```go
-// s1Conn, s5Conn is UPlaneConn retrieved with Dial() or ListenAndServe().
-relay := v1.NewRelay(s1Conn, s5Conn)
-
-// associate incoming TEID on S1 with outgoing TEID and address on S5, and vice versa.
-relay.AddPeer(s1TEIDIn, s5TEIDOut, s5Addr)
-relay.AddPeer(s5TEIDIn, s1TEIDOut, s1Addr)
-
-// make it start working by Run(), often good to work background.
-// if no peer is registered, it just drops the packets.
-go relay.Run()
-defer relay.Close()
+// this is the example for S-GW that completed establishing a session and ready to forward U-Plane packets.
+s1uConn.RelayTo(s5uConn, s1usgwTEID, s5uBearer.OutgoingTEID(), s5uBearer.RemoteAddress())
+s5uConn.RelayTo(s1uConn, s5usgwTEID, s1uBearer.OutgoingTEID(), s1uBearer.RemoteAddress())
 ```
 
-Note: _package v1 does provide encapsulation/decapsulation and some networking features, but it does not provide routing of the decapsulated packets, nor capturing IP layer and above on the specified interface. This is because such kind of operations cannot be done without platform-specific codes._
+_Note: _package v1 does provide encapsulation/decapsulation and some networking features, but it does not provide routing of the decapsulated packets, nor capturing IP layer and above on the specified interface. This is because such kind of operations cannot be done without platform-specific codes, But **netlink support is on its way**; stay tuned!_
 
 ## Supported Features
 
@@ -89,7 +82,7 @@ The following Messages marked with "Yes" are currently available with their own 
 _Even there are some missing Messages, you can create any kind of Message by using `messages.NewGeneric()`._
 
 | ID        | Name                                        | Supported |
-|-----------|---------------------------------------------|-----------|
+| --------- | ------------------------------------------- | --------- |
 | 0         | (Spare/Reserved)                            | -         |
 | 1         | Echo Request                                | Yes       |
 | 2         | Echo Response                               | Yes       |
@@ -177,7 +170,7 @@ The following Information Elements marked with "Yes" are currently supported wit
 _Even there are some missing IEs, you can create any kind of IEs by using `ies.New()` function or by initializing ies.IE directly._
 
 | ID      | Name                                      | Supported |
-|---------|-------------------------------------------|-----------|
+| ------- | ----------------------------------------- | --------- |
 | 0       | (Spare/Reserved)                          | -         |
 | 1       | Cause                                     | Yes       |
 | 2       | IMSI                                      | Yes       |

--- a/v1/relay.go
+++ b/v1/relay.go
@@ -5,17 +5,15 @@
 package v1
 
 import (
+	"log"
 	"net"
 	"sync"
 	"time"
 )
 
-type peer struct {
-	teid uint32
-	addr net.Addr
-}
-
 // Relay is to relay packets between two UPlaneConn.
+//
+// DEPRECATED. Use UPlaneConn.RelayTo() instead.
 type Relay struct {
 	mu                  sync.Mutex
 	closeCh             chan struct{}
@@ -24,7 +22,10 @@ type Relay struct {
 }
 
 // NewRelay creates a new Relay.
+//
+// DEPRECATED. Use UPlaneConn.RelayTo() instead.
 func NewRelay(leftConn, rightConn *UPlaneConn) *Relay {
+	log.Println("Relay is deprecated. Use UPlaneConn.RelayTo() instead.")
 	return &Relay{
 		mu:        sync.Mutex{},
 		closeCh:   make(chan struct{}),
@@ -36,6 +37,8 @@ func NewRelay(leftConn, rightConn *UPlaneConn) *Relay {
 
 // Run starts listening on both UPlaneConn.
 // Until peer information is registered by AddPeer(), it just drops packets.
+//
+// DEPRECATED. Use UPlaneConn.RelayTo() instead.
 func (r *Relay) Run() {
 	// from left to right
 	go func() {
@@ -91,6 +94,8 @@ func (r *Relay) Run() {
 }
 
 // Close closes Relay. It does not close the UPlaneConn given at first.
+//
+// DEPRECATED. Use UPlaneConn.RelayTo() instead.
 func (r *Relay) Close() error {
 	if err := r.leftConn.SetReadDeadline(time.Now().Add(time.Duration(1 * time.Millisecond))); err != nil {
 		return err
@@ -107,11 +112,13 @@ func (r *Relay) closed() <-chan struct{} {
 }
 
 // AddPeer adds a peer information with the TEID contained in the incoming meesage.
+//
+// DEPRECATED. Use UPlaneConn.RelayTo() instead.
 func (r *Relay) AddPeer(teidIn, teidOut uint32, raddr net.Addr) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	r.teidPair[teidIn] = &peer{teidOut, raddr}
+	r.teidPair[teidIn] = &peer{teid: teidOut, addr: raddr}
 }
 
 func (r *Relay) getPeer(teid uint32) (*peer, bool) {

--- a/v1/u-conn.go
+++ b/v1/u-conn.go
@@ -5,6 +5,7 @@
 package v1
 
 import (
+	"encoding/binary"
 	"net"
 	"strings"
 	"sync"
@@ -31,6 +32,8 @@ type UPlaneConn struct {
 	tpduCh  chan *tpduSet
 	closeCh chan struct{}
 	errCh   chan error
+
+	relayMap map[uint32]*peer
 
 	// RestartCounter is the RestartCounter value in Recovery IE, which represents how many
 	// times the GTPv2-C endpoint is restarted.
@@ -139,8 +142,40 @@ func (u *UPlaneConn) serve() {
 			continue
 		}
 
-		msg, err := messages.Decode(u.rcvBuf[:n])
+		payload := u.rcvBuf[:n]
+		msg, err := messages.Decode(payload)
 		if err != nil {
+			continue
+		}
+
+		// just forward T-PDU instead of passing it to reader
+		// if relayer is configured.
+		if len(u.relayMap) != 0 {
+			// handle by handleMessage() if it's not T-PDU.
+			if msg.MessageType() != messages.MsgTypeTPDU {
+				if err := u.handleMessage(raddr, msg); err != nil {
+					// errors should be handled by user
+					go func() {
+						u.errCh <- err
+					}()
+					continue
+				}
+			}
+
+			u.mu.Lock()
+			peer, ok := u.relayMap[msg.TEID()]
+			u.mu.Unlock()
+			if !ok {
+				continue
+			}
+
+			// just use original packet not to get it slow.
+			binary.BigEndian.PutUint32(payload[4:8], peer.teid)
+			if _, err := peer.srcConn.WriteTo(payload, peer.addr); err != nil {
+				go func() {
+					u.errCh <- err
+				}()
+			}
 			continue
 		}
 
@@ -372,4 +407,21 @@ func (u *UPlaneConn) RespondTo(raddr net.Addr, received, toBeSent messages.Messa
 // Restarts returns the number of restarts in uint8.
 func (u *UPlaneConn) Restarts() uint8 {
 	return u.RestartCounter
+}
+
+type peer struct {
+	teid    uint32
+	addr    net.Addr
+	srcConn *UPlaneConn
+}
+
+// RelayTo relays T-PDU type of packet to peer node(specified by raddr) from the UPlaneConn given.
+//
+// By using this, owner of UPlaneConn won't be able to Read and Write the packets that has teidIn.
+func (u *UPlaneConn) RelayTo(c *UPlaneConn, teidIn, teidOut uint32, raddr net.Addr) error {
+	if u.relayMap == nil {
+		u.relayMap = map[uint32]*peer{}
+	}
+	u.relayMap[teidIn] = &peer{teid: teidOut, addr: raddr, srcConn: c}
+	return nil
 }


### PR DESCRIPTION
To forward GTPv1-U packet more efficiently(=faster, fewer resource consumption), add `RelayTo()` method to `*v1.UPlaneConn`.

This deprecates `Relay`, which was too bad at forwarding many packets.