### PR TITLE
Improved session handling in S-GW

### DIFF
--- a/examples/sgw/s5.go
+++ b/examples/sgw/s5.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/pkg/errors"
+	v2 "github.com/wmnsk/go-gtp/v2"
+	"github.com/wmnsk/go-gtp/v2/ies"
+	"github.com/wmnsk/go-gtp/v2/messages"
+)
+
+func handleCreateSessionResponse(s5cConn *v2.Conn, pgwAddr net.Addr, msg messages.Message) error {
+	loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), pgwAddr)
+
+	s5Session, err := s5cConn.GetSessionByTEID(msg.TEID())
+	if err != nil {
+		return err
+	}
+
+	// assert type to refer to the struct field specific to the message.
+	// in general, no need to check if it can be type-asserted, as long as the MessageType is
+	// specified correctly in AddHandler().
+	csRspFromPGW := msg.(*messages.CreateSessionResponse)
+
+	// check Cause value first.
+	if ie := csRspFromPGW.Cause; ie != nil {
+		if cause := ie.Cause(); cause != v2.CauseRequestAccepted {
+			s5cConn.RemoveSession(s5Session)
+			// this is not such a fatal error worth stopping the whole program.
+			// in the real case it is better to take some action based on the Cause, though.
+			return &v2.ErrCauseNotOK{
+				MsgType: csRspFromPGW.MessageTypeName(),
+				Cause:   cause,
+				Msg:     fmt.Sprintf("subscriber: %s", s5Session.IMSI),
+			}
+		}
+	} else {
+		s5cConn.RemoveSession(s5Session)
+		return &v2.ErrRequiredIEMissing{
+			Type: ies.Cause,
+		}
+	}
+
+	bearer := s5Session.GetDefaultBearer()
+	// retrieve values that P-GW gave.
+	if ie := csRspFromPGW.PAA; ie != nil {
+		bearer.SubscriberIP = ie.IPAddress()
+	} else {
+		s5cConn.RemoveSession(s5Session)
+		return &v2.ErrRequiredIEMissing{Type: ies.PDNAddressAllocation}
+	}
+	if ie := csRspFromPGW.PGWS5S8FTEIDC; ie != nil {
+		s5Session.AddTEID(ie.InterfaceType(), ie.TEID())
+	} else {
+		s5cConn.RemoveSession(s5Session)
+		return &v2.ErrRequiredIEMissing{Type: ies.FullyQualifiedTEID}
+	}
+
+	if brCtxIE := csRspFromPGW.BearerContextsCreated; brCtxIE != nil {
+		for _, ie := range brCtxIE.ChildIEs {
+			switch ie.Type {
+			case ies.Cause:
+				if cause := ie.Cause(); cause != v2.CauseRequestAccepted {
+					s5cConn.RemoveSession(s5Session)
+					return &v2.ErrCauseNotOK{
+						MsgType: csRspFromPGW.MessageTypeName(),
+						Cause:   cause,
+						Msg:     fmt.Sprintf("subscriber: %s", s5Session.IMSI),
+					}
+				}
+			case ies.EPSBearerID:
+				bearer.EBI = ie.EPSBearerID()
+			case ies.FullyQualifiedTEID:
+				if err := handleFTEIDU(ie, s5Session, bearer); err != nil {
+					return err
+				}
+			case ies.ChargingID:
+				bearer.ChargingID = ie.ChargingID()
+			}
+		}
+	} else {
+		s5cConn.RemoveSession(s5Session)
+		return &v2.ErrRequiredIEMissing{Type: ies.BearerContext}
+	}
+
+	if err := s5Session.Activate(); err != nil {
+		s5cConn.RemoveSession(s5Session)
+		return err
+	}
+
+	// notify S11
+	imsi, err := s5cConn.GetIMSIByTEID(msg.TEID())
+	if err != nil {
+		return err
+	}
+	s11Session, err := s11Conn.GetSessionByIMSI(imsi)
+	if err != nil {
+		return err
+	}
+
+	if err := v2.PassMessageTo(s11Session, csRspFromPGW, 5*time.Second); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func handleDeleteSessionResponse(s5cConn *v2.Conn, pgwAddr net.Addr, msg messages.Message) error {
+	loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), pgwAddr)
+
+	session, err := s5cConn.GetSessionByTEID(msg.TEID())
+	if err != nil {
+		// this is not such a fatal error worth stopping the whole program.
+		loggerCh <- errors.Wrap(err, "Error").Error()
+		return nil
+	}
+
+	loggerCh <- fmt.Sprintf("Session deleted with P-GW for Subscriber: %s", session.IMSI)
+	s5cConn.RemoveSession(session)
+	delCh <- struct{}{}
+	return nil
+}

--- a/examples/sgw/sgw.go
+++ b/examples/sgw/sgw.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -50,12 +49,6 @@ func handleCreateSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 	if err != nil {
 		return err
 	}
-	if s5cConn == nil {
-		s5cConn, err = v2.Dial(laddr, raddr, 0, errCh)
-		if err != nil {
-			return err
-		}
-	}
 
 	// keep session information retrieved from the message.
 	// XXX - should return error if required IE is missing.
@@ -92,115 +85,7 @@ func handleCreateSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 	}
 	s11Conn.AddSession(s11Session)
 
-	// register handlers in s11Conn before sending CreateSession to P-GW.
-	createCh := make(chan *messages.CreateSessionResponse)
-	s5cConn.AddHandler(
-		messages.MsgTypeCreateSessionResponse,
-		func(s5cConn *v2.Conn, pgwAddr net.Addr, msg messages.Message) error {
-			loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), pgwAddr)
-
-			s5Session, err := s5cConn.GetSessionByTEID(msg.TEID())
-			if err != nil {
-				return err
-			}
-
-			// assert type to refer to the struct field specific to the message.
-			// in general, no need to check if it can be type-asserted, as long as the MessageType is
-			// specified correctly in AddHandler().
-			csRspFromPGW := msg.(*messages.CreateSessionResponse)
-
-			// check Cause value first.
-			if ie := csRspFromPGW.Cause; ie != nil {
-				if cause := ie.Cause(); cause != v2.CauseRequestAccepted {
-					s5cConn.RemoveSession(s5Session)
-					// this is not such a fatal error worth stopping the whole program.
-					// in the real case it is better to take some action based on the Cause, though.
-					return &v2.ErrCauseNotOK{
-						MsgType: csRspFromPGW.MessageTypeName(),
-						Cause:   cause,
-						Msg:     fmt.Sprintf("subscriber: %s", s5Session.IMSI),
-					}
-				}
-			} else {
-				s5cConn.RemoveSession(s5Session)
-				return &v2.ErrRequiredIEMissing{
-					Type: ies.Cause,
-				}
-			}
-
-			bearer := s5Session.GetDefaultBearer()
-			// retrieve values that P-GW gave.
-			if ie := csRspFromPGW.PAA; ie != nil {
-				bearer.SubscriberIP = ie.IPAddress()
-			} else {
-				s5cConn.RemoveSession(s5Session)
-				return &v2.ErrRequiredIEMissing{Type: ies.PDNAddressAllocation}
-			}
-			if ie := csRspFromPGW.PGWS5S8FTEIDC; ie != nil {
-				s5Session.AddTEID(ie.InterfaceType(), ie.TEID())
-			} else {
-				s5cConn.RemoveSession(s5Session)
-				return &v2.ErrRequiredIEMissing{Type: ies.FullyQualifiedTEID}
-			}
-
-			if brCtxIE := csRspFromPGW.BearerContextsCreated; brCtxIE != nil {
-				for _, ie := range brCtxIE.ChildIEs {
-					switch ie.Type {
-					case ies.Cause:
-						if cause := ie.Cause(); cause != v2.CauseRequestAccepted {
-							s5cConn.RemoveSession(s5Session)
-							return &v2.ErrCauseNotOK{
-								MsgType: csRspFromPGW.MessageTypeName(),
-								Cause:   cause,
-								Msg:     fmt.Sprintf("subscriber: %s", s5Session.IMSI),
-							}
-						}
-					case ies.EPSBearerID:
-						bearer.EBI = ie.EPSBearerID()
-					case ies.FullyQualifiedTEID:
-						if err := handleFTEIDU(ie, s5Session, bearer); err != nil {
-							return err
-						}
-					case ies.ChargingID:
-						bearer.ChargingID = ie.ChargingID()
-					}
-				}
-			} else {
-				s5cConn.RemoveSession(s5Session)
-				return &v2.ErrRequiredIEMissing{Type: ies.BearerContext}
-			}
-
-			if err := s5Session.Activate(); err != nil {
-				s5cConn.RemoveSession(s5Session)
-				return err
-			}
-
-			go func() {
-				createCh <- csRspFromPGW
-			}()
-			return nil
-		},
-	)
-	s5cConn.AddHandler(
-		messages.MsgTypeDeleteSessionResponse,
-		func(s5cConn *v2.Conn, pgwAddr net.Addr, msg messages.Message) error {
-			loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), pgwAddr)
-
-			session, err := s5cConn.GetSessionByTEID(msg.TEID())
-			if err != nil {
-				// this is not such a fatal error worth stopping the whole program.
-				loggerCh <- errors.Wrap(err, "Error").Error()
-				return nil
-			}
-
-			loggerCh <- fmt.Sprintf("Session deleted with P-GW for Subscriber: %s", session.IMSI)
-			s5cConn.RemoveSession(session)
-			delCh <- struct{}{}
-			return nil
-		},
-	)
-
-	s5cIP := strings.Split(laddr.IP.String(), ":")[0]
+	s5cIP := laddr.IP.String()
 	s5cFTEID := s5cConn.NewFTEID(v2.IFTypeS5S8SGWGTPC, s5cIP, "")
 	s5uFTEID := s5cConn.NewFTEID(v2.IFTypeS5S8SGWGTPU, s5cIP, "").WithInstance(2)
 
@@ -235,27 +120,9 @@ func handleCreateSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 			failCh <- err
 			return
 		}
-		select {
-		case csRspFromPGW := <-createCh:
-			// if everything in CreateSessionResponse seems OK, relay it to MME.
-			s11IP := strings.Split(*s11, ":")[0]
-			senderFTEID := s11Conn.NewFTEID(v2.IFTypeS11S4SGWGTPC, s11IP, "")
-			s1usgwFTEID := s11Conn.NewFTEID(v2.IFTypeS1USGWGTPU, s11IP, "")
-			csRspFromSGW = csRspFromPGW
-			csRspFromSGW.SenderFTEIDC = senderFTEID
-			csRspFromSGW.SGWFQCSID = ies.NewFullyQualifiedCSID(laddr.IP.String(), 1).WithInstance(1)
-			csRspFromSGW.BearerContextsCreated.Add(s1usgwFTEID)
-			csRspFromSGW.BearerContextsCreated.Remove(ies.ChargingID, 0)
-			csRspFromSGW.SetTEID(s11mmeTEID)
-			csRspFromSGW.SetLength()
 
-			if err := s11Conn.RespondTo(mmeAddr, csReqFromMME, csRspFromSGW); err != nil {
-				failCh <- err
-				return
-			}
-			s11Session.AddTEID(senderFTEID.InterfaceType(), senderFTEID.TEID())
-			s11Session.AddTEID(s1usgwFTEID.InterfaceType(), s1usgwFTEID.TEID())
-		case <-time.After(5 * time.Second):
+		message, err := s11Session.WaitMessage(5 * time.Second)
+		if err != nil {
 			csRspFromSGW = messages.NewCreateSessionResponse(
 				s11mmeTEID, 0,
 				ies.NewCause(v2.CauseNoResourcesAvailable, 0, 0, 0, nil),
@@ -268,7 +135,39 @@ func handleCreateSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 			loggerCh <- fmt.Sprintf("Sent %s with failure code: %d, target subscriber: %s", csRspFromSGW.MessageTypeName(), v2.CausePGWNotResponding, s11Session.IMSI)
 			failCh <- v2.ErrTimeout
 			return
+
 		}
+
+		var csRspFromPGW *messages.CreateSessionResponse
+		switch m := message.(type) {
+		case *messages.CreateSessionResponse:
+			// move forward
+			csRspFromPGW = m
+		default:
+			failCh <- v2.ErrUnexpectedType
+			return
+		}
+		// if everything in CreateSessionResponse seems OK, relay it to MME.
+		s11IP, _, err := net.SplitHostPort(*s11)
+		if err != nil {
+			return
+		}
+		senderFTEID := s11Conn.NewFTEID(v2.IFTypeS11S4SGWGTPC, s11IP, "")
+		s1usgwFTEID := s11Conn.NewFTEID(v2.IFTypeS1USGWGTPU, s11IP, "")
+		csRspFromSGW = csRspFromPGW
+		csRspFromSGW.SenderFTEIDC = senderFTEID
+		csRspFromSGW.SGWFQCSID = ies.NewFullyQualifiedCSID(laddr.IP.String(), 1).WithInstance(1)
+		csRspFromSGW.BearerContextsCreated.Add(s1usgwFTEID)
+		csRspFromSGW.BearerContextsCreated.Remove(ies.ChargingID, 0)
+		csRspFromSGW.SetTEID(s11mmeTEID)
+		csRspFromSGW.SetLength()
+
+		if err := s11Conn.RespondTo(mmeAddr, csReqFromMME, csRspFromSGW); err != nil {
+			failCh <- err
+			return
+		}
+		s11Session.AddTEID(senderFTEID.InterfaceType(), senderFTEID.TEID())
+		s11Session.AddTEID(s1usgwFTEID.InterfaceType(), s1usgwFTEID.TEID())
 
 		s11sgwTEID, err := s11Session.GetTEID(v2.IFTypeS11S4SGWGTPC)
 		if err != nil {

--- a/v1/README.md
+++ b/v1/README.md
@@ -63,7 +63,7 @@ if _, err := uConn.WriteToGTP(teid, payload, addr); err != nil {
 ```
 
 For SGSN/S-GW-ish nodes, this package provides a method to swap TEID and forward T-PDU packets efficiently.  
-By using `*UPlaneConn.Relay()`, the connection automatically handles the T-PDU packet in background with the least cost.
+By using `*UPlaneConn.RelayTo()`, the connection automatically handles the T-PDU packet in background with the least cost.
 
 ```go
 // this is the example for S-GW that completed establishing a session and ready to forward U-Plane packets.

--- a/v2/conn.go
+++ b/v2/conn.go
@@ -7,6 +7,7 @@ package v2
 import (
 	"crypto/rand"
 	"encoding/binary"
+	"log"
 	"net"
 	"sync"
 	"time"
@@ -551,6 +552,9 @@ func (c *Conn) GetSessionByTEID(teid uint32) (*Session, error) {
 
 // GetSessionByIMSI returns the current session looked up by IMSI.
 func (c *Conn) GetSessionByIMSI(imsi string) (*Session, error) {
+	if c.Sessions == nil {
+		log.Fatal(ErrUnknownIMSI)
+	}
 	for _, sess := range c.Sessions {
 		if imsi == sess.IMSI {
 			return sess, nil


### PR DESCRIPTION
Add `PassMessageTo()` and `WaitMessage()` to send/receive messages targeted to specific session.
This is expected to be used in the nodes that has multiple GTP interfaces like S-GW.
