### PR TITLE
Add Delete Bearer Request/Response support for S-GW

### DIFF
--- a/examples/sgw/main.go
+++ b/examples/sgw/main.go
@@ -53,6 +53,7 @@ type sGateway struct {
 
 	loggerCh chan string
 	errCh    chan error
+	msgChCh  chan chan messages.Message
 }
 
 func newSGW(s11, s5c, s1u, s5u net.Addr) (*sGateway, error) {

--- a/examples/sgw/s5.go
+++ b/examples/sgw/s5.go
@@ -107,9 +107,7 @@ func handleDeleteSessionResponse(s5cConn *v2.Conn, pgwAddr net.Addr, msg message
 
 	s5Session, err := s5cConn.GetSessionByTEID(msg.TEID())
 	if err != nil {
-		// this is not such a fatal error worth stopping the whole program.
-		sgw.loggerCh <- errors.Wrap(err, "Error").Error()
-		return nil
+		return err
 	}
 
 	s11Session, err := sgw.s11Conn.GetSessionByIMSI(s5Session.IMSI)
@@ -122,7 +120,138 @@ func handleDeleteSessionResponse(s5cConn *v2.Conn, pgwAddr net.Addr, msg message
 	}
 
 	// even the cause indicates failure, session should be removed locally.
-	sgw.loggerCh <- fmt.Sprintf("Session deleted with P-GW for Subscriber: %s", s5Session.IMSI)
+	sgw.loggerCh <- fmt.Sprintf("Session deleted for Subscriber: %s", s5Session.IMSI)
 	s5cConn.RemoveSession(s5Session)
 	return nil
+}
+
+func handleDeleteBearerRequest(s5cConn *v2.Conn, pgwAddr net.Addr, msg messages.Message) error {
+	sgw.loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), pgwAddr)
+
+	s5Session, err := s5cConn.GetSessionByTEID(msg.TEID())
+	if err != nil {
+		return err
+	}
+
+	s11Session, err := sgw.s11Conn.GetSessionByIMSI(s5Session.IMSI)
+	if err != nil {
+		return err
+	}
+
+	s5cpgwTEID, err := s5Session.GetTEID(v2.IFTypeS5S8PGWGTPC)
+	if err != nil {
+		return err
+	}
+
+	s11mmeTEID, err := s11Session.GetTEID(v2.IFTypeS11MMEGTPC)
+	if err != nil {
+		return err
+	}
+
+	// assert type to refer to the struct field specific to the message.
+	// in general, no need to check if it can be type-asserted, as long as the MessageType is
+	// specified correctly in AddHandler().
+	dbReqFromPGW := msg.(*messages.DeleteBearerRequest)
+
+	var dbRspFromSGW *messages.DeleteBearerResponse
+	var ebi *ies.IE
+	if ie := dbReqFromPGW.LinkedEBI; ie != nil {
+		ebi = ie
+	}
+	if ie := dbReqFromPGW.EBI; ie != nil {
+		// shouldn't be both.
+		if ebi != nil {
+			dbRspFromSGW = messages.NewDeleteBearerResponse(
+				s5cpgwTEID, 0,
+				ies.NewCause(v2.CauseContextNotFound, 0, 0, 0, ie),
+			)
+			if err := s5cConn.RespondTo(pgwAddr, dbReqFromPGW, dbRspFromSGW); err != nil {
+				return err
+			}
+			return errors.Errorf(
+				"%T from %s had both Linked EBI and EBIs IE",
+				dbReqFromPGW, pgwAddr,
+			)
+		}
+		ebi = ie
+	}
+
+	if ebi == nil {
+		dbRspFromSGW = messages.NewDeleteBearerResponse(
+			s5cpgwTEID, 0, ies.NewCause(v2.CauseMandatoryIEMissing,
+				0, 0, 0, ies.NewEPSBearerID(0),
+			),
+		)
+		if err := s5cConn.RespondTo(pgwAddr, dbReqFromPGW, dbRspFromSGW); err != nil {
+			return err
+		}
+		return err
+	}
+
+	// check if bearer associated with EBI exists or not.
+	_, err = s5Session.LookupBearerByEBI(ebi.EPSBearerID())
+	if err != nil {
+		dbRspFromSGW = messages.NewDeleteBearerResponse(
+			s5cpgwTEID, 0,
+			ies.NewCause(v2.CauseContextNotFound, 0, 0, 0, nil),
+		)
+		if err := s5cConn.RespondTo(pgwAddr, dbReqFromPGW, dbRspFromSGW); err != nil {
+			return err
+		}
+		return err
+	}
+
+	// forward to MME
+	if err := sgw.s11Conn.DeleteBearer(s11mmeTEID, ebi); err != nil {
+		return err
+	}
+
+	// wait for response from MME for 5 seconds
+	doneCh := make(chan struct{})
+	failCh := make(chan error)
+	go func() {
+		message, err := s5Session.WaitMessage(5 * time.Second)
+		if err != nil {
+			dbRspFromSGW = messages.NewDeleteBearerResponse(
+				s5cpgwTEID, 0,
+				ies.NewCause(v2.CauseNoResourcesAvailable, 0, 0, 0, nil),
+			)
+
+			if err := s5cConn.RespondTo(pgwAddr, dbReqFromPGW, dbRspFromSGW); err != nil {
+				failCh <- err
+				return
+			}
+			// remove anyway, as P-GW no longer keeps bearer locally
+			s5Session.RemoveBearerByEBI(ebi.EPSBearerID())
+			s11Session.RemoveBearerByEBI(ebi.EPSBearerID())
+			failCh <- err
+			return
+		}
+
+		switch m := message.(type) {
+		case *messages.DeleteBearerResponse:
+			// move forward
+			dbRspFromSGW = m
+		default:
+			failCh <- v2.ErrUnexpectedType
+			return
+		}
+
+		dbRspFromSGW.SetTEID(s5cpgwTEID)
+		if err := s5cConn.RespondTo(pgwAddr, msg, dbRspFromSGW); err != nil {
+			failCh <- err
+			return
+		}
+
+		s5Session.RemoveBearerByEBI(ebi.EPSBearerID())
+		s11Session.RemoveBearerByEBI(ebi.EPSBearerID())
+		doneCh <- struct{}{}
+	}()
+
+	select {
+	case <-doneCh:
+		return nil
+	case err := <-failCh:
+		return err
+	}
 }

--- a/v2/conn.go
+++ b/v2/conn.go
@@ -473,7 +473,7 @@ func (c *Conn) CreateSession(raddr net.Addr, ie ...*ies.IE) (*Session, error) {
 	return sess, nil
 }
 
-// DeleteSession sends a DeleteSessionRequest with EBI associated with the TEID given.
+// DeleteSession sends a DeleteSessionRequest with TEID and IEs given..
 func (c *Conn) DeleteSession(teid uint32, ie ...*ies.IE) error {
 	sess, err := c.GetSessionByTEID(teid)
 	if err != nil {
@@ -492,7 +492,7 @@ func (c *Conn) DeleteSession(teid uint32, ie ...*ies.IE) error {
 	return nil
 }
 
-// ModifyBearer sends a ModifyBearerRequest with EBI associated with the TEID given.
+// ModifyBearer sends a ModifyBearerRequest with TEID and IEs given..
 func (c *Conn) ModifyBearer(teid uint32, ie ...*ies.IE) error {
 	sess, err := c.GetSessionByTEID(teid)
 	if err != nil {
@@ -505,6 +505,25 @@ func (c *Conn) ModifyBearer(teid uint32, ie ...*ies.IE) error {
 	}
 
 	if _, err := c.WriteTo(mbr, sess.PeerAddr); err != nil {
+		return err
+	}
+	sess.Sequence++
+	return nil
+}
+
+// DeleteBearer sends a DeleteBearerRequest TEID and with IEs given.
+func (c *Conn) DeleteBearer(teid uint32, ie ...*ies.IE) error {
+	sess, err := c.GetSessionByTEID(teid)
+	if err != nil {
+		return err
+	}
+
+	dbr, err := messages.NewDeleteBearerRequest(teid, sess.Sequence+1, ie...).Serialize()
+	if err != nil {
+		return err
+	}
+
+	if _, err := c.WriteTo(dbr, sess.PeerAddr); err != nil {
 		return err
 	}
 	sess.Sequence++

--- a/v2/constants.go
+++ b/v2/constants.go
@@ -102,9 +102,9 @@ const (
 	CauseAllDynamicAddressesAreOccupied                                                 uint8 = 84
 	CauseUEContextWithoutTFTAlreadyActivated                                            uint8 = 85
 	CauseProtocolTypeNotSupported                                                       uint8 = 86
-	CauseUENotRespondinguint8                                                           uint8 = 87
+	CauseUENotResponding                                                                uint8 = 87
 	CauseUERefuses                                                                      uint8 = 88
-	CauseServiceDenieduint8                                                             uint8 = 89
+	CauseServiceDenied                                                                  uint8 = 89
 	CauseUnableToPageUE                                                                 uint8 = 90
 	CauseNoMemoryAvailable                                                              uint8 = 91
 	CauseUserAuthenticationFailed                                                       uint8 = 92

--- a/v2/session.go
+++ b/v2/session.go
@@ -209,6 +209,15 @@ func (s *Session) RemoveBearer(name string) {
 	s.bearerMap.delete(name)
 }
 
+// RemoveBearerByEBI removes a Bearer looked up by name.
+func (s *Session) RemoveBearerByEBI(ebi uint8) {
+	name, err := s.LookupBearerNameByEBI(ebi)
+	if err != nil {
+		return
+	}
+	s.bearerMap.delete(name)
+}
+
 // GetDefaultBearer returns the pointer to default bearer.
 func (s *Session) GetDefaultBearer() *Bearer {
 	// it is not expected that the default bearer cannot be found.
@@ -252,6 +261,25 @@ func (s *Session) LookupBearerByEBI(ebi uint8) (*Bearer, error) {
 
 	}
 	return bearer, nil
+}
+
+// LookupBearerNameByEBI looks up name of Bearer by EBI.
+func (s *Session) LookupBearerNameByEBI(ebi uint8) (string, error) {
+	var name string
+	s.bearerMap.rangeWithFunc(func(n, br interface{}) bool {
+		bearer := br.(*Bearer)
+		if ebi == bearer.EBI {
+			name = n.(string)
+			return false
+		}
+		return true
+	})
+
+	if name == "" {
+		return "", ErrNoBearerFound
+
+	}
+	return name, nil
 }
 
 // LookupEBIByName returns EBI associated with Name given.


### PR DESCRIPTION
Now `examples/sgw` can handle Delete Bearer Request/Response.
This PR also contains some helpers to handle bearers easier.
