### PR TITLE
Make golangci happy

### DIFF
--- a/v0/ies/ie.go
+++ b/v0/ies/ie.go
@@ -106,12 +106,12 @@ func (i *IE) UnmarshalBinary(b []byte) error {
 
 	i.Type = b[0]
 	if i.IsTV() {
-		return ParseTVFromBytes(i, b)
+		return parseTVFromBytes(i, b)
 	}
-	return ParseTLVFromBytes(i, b)
+	return parseTLVFromBytes(i, b)
 }
 
-func ParseTVFromBytes(i *IE, b []byte) error {
+func parseTVFromBytes(i *IE, b []byte) error {
 	l := len(b)
 	if l < 2 {
 		return ErrTooShortToParse
@@ -125,7 +125,7 @@ func ParseTVFromBytes(i *IE, b []byte) error {
 	return nil
 }
 
-func ParseTLVFromBytes(i *IE, b []byte) error {
+func parseTLVFromBytes(i *IE, b []byte) error {
 	l := len(b)
 	if l < 3 {
 		return ErrTooShortToParse
@@ -233,6 +233,7 @@ func newUint32ValIE(t uint8, v uint32) *IE {
 	return i
 }
 
-func newStringIE(t uint8, str string) *IE {
-	return New(t, []byte(str))
-}
+// left for future use.
+//func newStringIE(t uint8, str string) *IE {
+//	return New(t, []byte(str))
+//}

--- a/v1/ies/ie.go
+++ b/v1/ies/ie.go
@@ -362,11 +362,12 @@ func newUint8ValIE(t, v uint8) *IE {
 	return New(t, []byte{v})
 }
 
-func newUint16ValIE(t uint8, v uint16) *IE {
-	i := New(t, make([]byte, 2))
-	binary.BigEndian.PutUint16(i.Payload, v)
-	return i
-}
+// left for future use.
+//func newUint16ValIE(t uint8, v uint16) *IE {
+//	i := New(t, make([]byte, 2))
+//	binary.BigEndian.PutUint16(i.Payload, v)
+//	return i
+//}
 
 func newUint32ValIE(t uint8, v uint32) *IE {
 	i := New(t, make([]byte, 4))

--- a/v1/tunnel.go
+++ b/v1/tunnel.go
@@ -35,10 +35,12 @@ func (u *UPlaneConn) AddTunnelOverride(peerIP, msIP net.IP, otei, itei uint32) e
 	}
 
 	if pdp, _ := netlink.GTPPDPByMSAddress(u.GTPLink, msIP); pdp != nil {
-		netlink.GTPPDPDel(u.GTPLink, pdp)
+		// do nothing even this fails
+		_ = netlink.GTPPDPDel(u.GTPLink, pdp)
 	}
 	if pdp, _ := netlink.GTPPDPByITEI(u.GTPLink, int(itei)); pdp != nil {
-		netlink.GTPPDPDel(u.GTPLink, pdp)
+		// do nothing even this fails
+		_ = netlink.GTPPDPDel(u.GTPLink, pdp)
 	}
 
 	return u.AddTunnel(peerIP, msIP, otei, itei)

--- a/v2/ies/paa.go
+++ b/v2/ies/paa.go
@@ -19,7 +19,6 @@ const (
 //
 // The PDN Type field is automatically judged by the format of given addr,
 // If it cannot be converted as neither IPv4 nor IPv6, PDN Type will be Non-IP.
-// XXX - IPv4v6 not currently supported.
 func NewPDNAddressAllocation(addr string) *IE {
 	ip := net.ParseIP(addr)
 	v4 := ip.To4()
@@ -44,4 +43,28 @@ func NewPDNAddressAllocation(addr string) *IE {
 
 	// Non-IP
 	return New(PDNAddressAllocation, 0x00, []byte{pdnTypeNonIP})
+}
+
+// NewPDNAddressAllocationDual creates a new PDNAddressAllocation IE with
+// IPv4 address and IPv6 address given.
+//
+// If they cannot be converted as IPv4/IPv6, PDN Type will be Non-IP.
+func NewPDNAddressAllocationDual(v4addr, v6addr string) *IE {
+	v4 := net.ParseIP(v4addr).To4()
+	if v4 == nil {
+		return New(PDNAddressAllocation, 0x00, []byte{pdnTypeNonIP})
+	}
+
+	v6 := net.ParseIP(v6addr).To16()
+	if v6 == nil {
+		return New(PDNAddressAllocation, 0x00, []byte{pdnTypeNonIP})
+	}
+
+	i := New(PDNAddressAllocation, 0x00, make([]byte, 23))
+	i.Payload[0] = pdnTypeIPv4v6
+	copy(i.Payload[1:5], v4)
+	i.Payload[5] = 0x00
+	copy(i.Payload[6:], v6)
+
+	return i
 }


### PR DESCRIPTION
Fixed the following issues.

```
$ GOLANGCI_COM_RUN=1 golangci-lint run --out-format=json --issues-exit-code=0 --deadline=5m --new=false --new-from-rev= --new-from-patch=
    v1/ies/ie.go:365: `newUint16ValIE` is unused (deadcode)
    v0/ies/ie.go:236: `newStringIE` is unused (deadcode)
    v2/ies/paa.go:14: `pdnTypeIPv4v6` is unused (deadcode)
    v1/tunnel.go:38: Error return value of `netlink.GTPPDPDel` is not checked (errcheck)
    v1/tunnel.go:41: Error return value of `netlink.GTPPDPDel` is not checked (errcheck)
```