### PR TITLE
Fix a URL link to examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Package gtp provides simple and painless handling of GTP(GPRS Tunneling Protocol
 
 * No platform-specific codes inside, so it **works almost everywhere Golang works**.
 * Flexible enough to **control everything in GTP protocol**.;
-  * For developing mobile core network nodes (see [examples](./gtp/examples)).
+  * For developing mobile core network nodes (see [examples](./examples)).
   * For developing testing tools like traffic simulators or fuzzers.
 * Many **helpers kind to developers** provided, like session, bearer, and TEID associations.
 * Easy handling of **multiple connections with fixed IP and Port** with UDP (or other `net.PacketConn`).


### PR DESCRIPTION
Fix a URL link to examples directory in README.md.

Before: https://github.com/wmnsk/go-gtp/blob/master/gtp/examples
-> Shows a 404 error.

After: https://github.com/wmnsk/go-gtp/blob/master/examples
-> Shows a right examples page.