### PR TITLE
Fixed bugs in session handling

### DIFF
--- a/examples/mme/mme.go
+++ b/examples/mme/mme.go
@@ -17,7 +17,7 @@ func handleCreateSessionResponse(c *v2.Conn, sgwAddr net.Addr, msg messages.Mess
 	loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), sgwAddr)
 
 	// find the session associated with TEID
-	session, err := c.GetSessionByTEID(msg.TEID())
+	session, err := c.GetSessionByTEID(msg.TEID(), sgwAddr)
 	if err != nil {
 		c.RemoveSession(session)
 		return err
@@ -117,7 +117,7 @@ func handleCreateSessionResponse(c *v2.Conn, sgwAddr net.Addr, msg messages.Mess
 func handleModifyBearerResponse(c *v2.Conn, sgwAddr net.Addr, msg messages.Message) error {
 	loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), sgwAddr)
 
-	session, err := c.GetSessionByTEID(msg.TEID())
+	session, err := c.GetSessionByTEID(msg.TEID(), sgwAddr)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func handleModifyBearerResponse(c *v2.Conn, sgwAddr net.Addr, msg messages.Messa
 func handleDeleteSessionResponse(c *v2.Conn, sgwAddr net.Addr, msg messages.Message) error {
 	loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), sgwAddr)
 
-	session, err := c.GetSessionByTEID(msg.TEID())
+	session, err := c.GetSessionByTEID(msg.TEID(), sgwAddr)
 	if err != nil {
 		return err
 	}

--- a/examples/mme/mock.go
+++ b/examples/mme/mock.go
@@ -67,7 +67,7 @@ func handleAttach(raddr net.Addr, c *v2.Conn, sub *v2.Subscriber, br *v2.Bearer)
 			return v2.ErrTEIDNotFound
 		}
 		// send Delete Session Request to cleanup sessions in S/P-GW.
-		if _, err := c.DeleteSession(teid); err != nil {
+		if _, err := c.DeleteSession(teid, sess.PeerAddr); err != nil {
 			return errors.Wrap(err, "got something unexpected")
 		}
 		c.RemoveSession(sess)

--- a/examples/pgw/pgw.go
+++ b/examples/pgw/pgw.go
@@ -251,7 +251,7 @@ func handleDeleteSessionRequest(c *v2.Conn, sgwAddr net.Addr, msg messages.Messa
 	// assert type to refer to the struct field specific to the message.
 	// in general, no need to check if it can be type-asserted, as long as the MessageType is
 	// specified correctly in AddHandler().
-	session, err := c.GetSessionByTEID(msg.TEID())
+	session, err := c.GetSessionByTEID(msg.TEID(), sgwAddr)
 	if err != nil {
 		dsr := messages.NewDeleteSessionResponse(
 			0, 0,

--- a/examples/sgw/s11.go
+++ b/examples/sgw/s11.go
@@ -256,7 +256,7 @@ func handleCreateSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 func handleModifyBearerRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages.Message) error {
 	sgw.loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), mmeAddr)
 
-	s11Session, err := s11Conn.GetSessionByTEID(msg.TEID())
+	s11Session, err := s11Conn.GetSessionByTEID(msg.TEID(), mmeAddr)
 	if err != nil {
 		return err
 	}
@@ -335,7 +335,7 @@ func handleDeleteSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 	// specified correctly in AddHandler().
 	dsReqFromMME := msg.(*messages.DeleteSessionRequest)
 
-	s11Session, err := s11Conn.GetSessionByTEID(msg.TEID())
+	s11Session, err := s11Conn.GetSessionByTEID(msg.TEID(), mmeAddr)
 	if err != nil {
 		return err
 	}
@@ -352,6 +352,7 @@ func handleDeleteSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 
 	seq, err := sgw.s5cConn.DeleteSession(
 		s5cpgwTEID,
+		s5Session.PeerAddr,
 		ies.NewEPSBearerID(s5Session.GetDefaultBearer().EBI),
 	)
 	if err != nil {
@@ -404,7 +405,7 @@ func handleDeleteSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 func handleDeleteBearerResponse(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages.Message) error {
 	sgw.loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), mmeAddr)
 
-	s11Session, err := s11Conn.GetSessionByTEID(msg.TEID())
+	s11Session, err := s11Conn.GetSessionByTEID(msg.TEID(), mmeAddr)
 	if err != nil {
 		return err
 	}

--- a/examples/sgw/s5.go
+++ b/examples/sgw/s5.go
@@ -14,7 +14,7 @@ import (
 func handleCreateSessionResponse(s5cConn *v2.Conn, pgwAddr net.Addr, msg messages.Message) error {
 	sgw.loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), pgwAddr)
 
-	s5Session, err := s5cConn.GetSessionByTEID(msg.TEID())
+	s5Session, err := s5cConn.GetSessionByTEID(msg.TEID(), pgwAddr)
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func handleCreateSessionResponse(s5cConn *v2.Conn, pgwAddr net.Addr, msg message
 func handleDeleteSessionResponse(s5cConn *v2.Conn, pgwAddr net.Addr, msg messages.Message) error {
 	sgw.loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), pgwAddr)
 
-	s5Session, err := s5cConn.GetSessionByTEID(msg.TEID())
+	s5Session, err := s5cConn.GetSessionByTEID(msg.TEID(), pgwAddr)
 	if err != nil {
 		return err
 	}
@@ -156,7 +156,7 @@ func handleDeleteSessionResponse(s5cConn *v2.Conn, pgwAddr net.Addr, msg message
 func handleDeleteBearerRequest(s5cConn *v2.Conn, pgwAddr net.Addr, msg messages.Message) error {
 	sgw.loggerCh <- fmt.Sprintf("Received %s from %s", msg.MessageTypeName(), pgwAddr)
 
-	s5Session, err := s5cConn.GetSessionByTEID(msg.TEID())
+	s5Session, err := s5cConn.GetSessionByTEID(msg.TEID(), pgwAddr)
 	if err != nil {
 		return err
 	}
@@ -230,7 +230,7 @@ func handleDeleteBearerRequest(s5cConn *v2.Conn, pgwAddr net.Addr, msg messages.
 	}
 
 	// forward to MME
-	seq, err := sgw.s11Conn.DeleteBearer(s11mmeTEID, ebi)
+	seq, err := sgw.s11Conn.DeleteBearer(s11mmeTEID, s11Session.PeerAddr, ebi)
 	if err != nil {
 		return err
 	}

--- a/v2/errors.go
+++ b/v2/errors.go
@@ -124,11 +124,22 @@ func (e *ErrUnknownAPN) Error() string {
 	return fmt.Sprintf("got unknown APN: %s", e.APN)
 }
 
+// ErrInvalidSession indicates that something went wrong with Session.
+type ErrInvalidSession struct {
+	IMSI string
+}
+
+// Error returns message with IMSI associated with Session if available.
+func (e ErrInvalidSession) Error() string {
+	return fmt.Sprintf("invalid session, IMSI: %s", e.IMSI)
+}
+
 // ErrNoBearerFound indicates that no Bearer found by lookup methods.
 type ErrNoBearerFound struct {
 	IMSI string
 }
 
+// Error returns message with IMSI associated with Bearer if available.
 func (e ErrNoBearerFound) Error() string {
 	return fmt.Sprintf("no Bearer found: %s", e.IMSI)
 }

--- a/v2/helpers_test.go
+++ b/v2/helpers_test.go
@@ -9,14 +9,15 @@ import (
 )
 
 var testConn *v2.Conn
+var dummyAddr net.Addr = &net.UDPAddr{IP: net.IP{0x00, 0x00, 0x00, 0x00}, Port: 2123}
 
 func init() {
 	testConn = &v2.Conn{
 		Sessions: []*v2.Session{
-			v2.NewSession(&net.UDPAddr{}, &v2.Subscriber{IMSI: "001011234567891"}),
-			v2.NewSession(&net.UDPAddr{}, &v2.Subscriber{IMSI: "001011234567892"}),
-			v2.NewSession(&net.UDPAddr{}, &v2.Subscriber{IMSI: "001011234567893"}),
-			v2.NewSession(&net.UDPAddr{}, &v2.Subscriber{IMSI: "001011234567894"}),
+			v2.NewSession(dummyAddr, &v2.Subscriber{IMSI: "001011234567891"}),
+			v2.NewSession(dummyAddr, &v2.Subscriber{IMSI: "001011234567892"}),
+			v2.NewSession(dummyAddr, &v2.Subscriber{IMSI: "001011234567893"}),
+			v2.NewSession(dummyAddr, &v2.Subscriber{IMSI: "001011234567894"}),
 		},
 	}
 
@@ -47,7 +48,7 @@ func TestGetSessionByIMSI_GetTEID(t *testing.T) {
 
 func TestGetSessionByTEID(t *testing.T) {
 	for i := 1; i <= len(testConn.Sessions); i++ {
-		sess, err := testConn.GetSessionByTEID(uint32(i))
+		sess, err := testConn.GetSessionByTEID(uint32(i), dummyAddr)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -61,7 +62,7 @@ func TestGetSessionByTEID(t *testing.T) {
 
 func TestGetIMSIByTEID(t *testing.T) {
 	for i := 1; i <= len(testConn.Sessions); i++ {
-		imsi, err := testConn.GetIMSIByTEID(uint32(i))
+		imsi, err := testConn.GetIMSIByTEID(uint32(i), dummyAddr)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Sessions(TEIDs) should be associated with peer address but it wasn't.

* add checks of peer's address matches or not when looking up
* fix timing issue that might happen in PassMessage / WaitMessage funcs
