### PR TITLE
Performance improvements for GTPv2

### DIFF
--- a/examples/mme/main.go
+++ b/examples/mme/main.go
@@ -154,7 +154,7 @@ func main() {
 
 				if _, err := s11Conn.ModifyBearer(
 					teid,
-					sess.PeerAddr,
+					sess.PeerAddr(),
 					ies.NewIndicationFromOctets(0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00),
 					ies.NewBearerContext(ies.NewEPSBearerID(sess.GetDefaultBearer().EBI), enbFTEID),
 				); err != nil {
@@ -183,7 +183,7 @@ func main() {
 					errCh <- v2.ErrTEIDNotFound
 					return
 				}
-				if _, err := s11Conn.DeleteSession(teid, sess.PeerAddr); err != nil {
+				if _, err := s11Conn.DeleteSession(teid, sess.PeerAddr()); err != nil {
 					log.Printf("Warning: %s", err)
 				}
 				delWG.Add(1)

--- a/examples/mme/mock.go
+++ b/examples/mme/mock.go
@@ -67,7 +67,7 @@ func handleAttach(raddr net.Addr, c *v2.Conn, sub *v2.Subscriber, br *v2.Bearer)
 			return v2.ErrTEIDNotFound
 		}
 		// send Delete Session Request to cleanup sessions in S/P-GW.
-		if _, err := c.DeleteSession(teid, sess.PeerAddr); err != nil {
+		if _, err := c.DeleteSession(teid, sess.PeerAddr()); err != nil {
 			return errors.Wrap(err, "got something unexpected")
 		}
 		c.RemoveSession(sess)

--- a/examples/sgw/s11.go
+++ b/examples/sgw/s11.go
@@ -360,7 +360,7 @@ func handleDeleteSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 
 	seq, err := sgw.s5cConn.DeleteSession(
 		s5cpgwTEID,
-		s5Session.PeerAddr,
+		s5Session.PeerAddr(),
 		ies.NewEPSBearerID(s5Session.GetDefaultBearer().EBI),
 	)
 	if err != nil {

--- a/examples/sgw/s5.go
+++ b/examples/sgw/s5.go
@@ -230,7 +230,7 @@ func handleDeleteBearerRequest(s5cConn *v2.Conn, pgwAddr net.Addr, msg messages.
 	}
 
 	// forward to MME
-	seq, err := sgw.s11Conn.DeleteBearer(s11mmeTEID, s11Session.PeerAddr, ebi)
+	seq, err := sgw.s11Conn.DeleteBearer(s11mmeTEID, s11Session.PeerAddr(), ebi)
 	if err != nil {
 		return err
 	}

--- a/v2/bearer.go
+++ b/v2/bearer.go
@@ -8,7 +8,7 @@ import (
 	"net"
 )
 
-// QoSProfile is a QoS-related information that belongs to a Bearer.
+// QoSProfile represents a QoS-related information that belongs to a Bearer.
 type QoSProfile struct {
 	PCI, PVI bool
 	PL, QCI  uint8
@@ -18,7 +18,7 @@ type QoSProfile struct {
 	GBRUL, GBRDL uint64
 }
 
-// Bearer is a GTPv2 bearer.
+// Bearer represents a GTPv2 bearer.
 type Bearer struct {
 	raddr           net.Addr
 	teidIn, teidOut uint32

--- a/v2/conn.go
+++ b/v2/conn.go
@@ -594,7 +594,7 @@ func (c *Conn) DeleteSession(teid uint32, raddr net.Addr, ie ...*ies.IE) (uint32
 
 	msg := messages.NewDeleteSessionRequest(teid, 0, ie...)
 
-	seq, err := c.SendMessageTo(msg, sess.PeerAddr)
+	seq, err := c.SendMessageTo(msg, sess.peerAddr)
 	if err != nil {
 		return 0, err
 	}
@@ -610,7 +610,7 @@ func (c *Conn) ModifyBearer(teid uint32, raddr net.Addr, ie ...*ies.IE) (uint32,
 
 	msg := messages.NewModifyBearerRequest(teid, 0, ie...)
 
-	seq, err := c.SendMessageTo(msg, sess.PeerAddr)
+	seq, err := c.SendMessageTo(msg, sess.peerAddr)
 	if err != nil {
 		return 0, err
 	}
@@ -626,7 +626,7 @@ func (c *Conn) DeleteBearer(teid uint32, raddr net.Addr, ie ...*ies.IE) (uint32,
 
 	msg := messages.NewDeleteBearerRequest(teid, 0, ie...)
 
-	seq, err := c.SendMessageTo(msg, sess.PeerAddr)
+	seq, err := c.SendMessageTo(msg, sess.peerAddr)
 	if err != nil {
 		return 0, err
 	}
@@ -658,7 +658,7 @@ func (c *Conn) GetSessionByTEID(teid uint32, peer net.Addr) (*Session, error) {
 
 	var session *Session
 	for _, sess := range c.Sessions {
-		if peer.String() != sess.PeerAddr.String() {
+		if peer.String() != sess.peerAddrString {
 			continue
 		}
 

--- a/v2/conn.go
+++ b/v2/conn.go
@@ -753,6 +753,22 @@ func (c *Conn) RemoveSession(session *Session) {
 	c.Sessions = newSessions
 }
 
+// RemoveSessionByIMSI removes a session looked up by IMSI.
+func (c *Conn) RemoveSessionByIMSI(imsi string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	var newSessions []*Session
+	for _, sess := range c.Sessions {
+		if imsi == sess.IMSI {
+			continue
+		}
+		newSessions = append(newSessions, sess)
+	}
+
+	c.Sessions = newSessions
+}
+
 // NewFTEID creates a new F-TEID with random TEID value that is unique within Conn.
 // If there's a lot of Session on the Conn, it may take a long time to find unique one.
 func (c *Conn) NewFTEID(ifType uint8, v4, v6 string) (fteidIE *ies.IE) {

--- a/v2/helpers_test.go
+++ b/v2/helpers_test.go
@@ -22,6 +22,7 @@ func init() {
 	}
 
 	for i, sess := range testConn.Sessions {
+		_ = sess.Activate()
 		sess.AddTEID(v2.IFTypeS11MMEGTPC, uint32(i+1))
 		testConn.AddSession(sess)
 	}
@@ -71,5 +72,53 @@ func TestGetIMSIByTEID(t *testing.T) {
 		if string(imsi[14]) != lastDigit {
 			t.Errorf("Got wrong IMSI at %d, %s", i, imsi)
 		}
+	}
+}
+
+func TestRemoveSession(t *testing.T) {
+	conn := *testConn // copy testConn
+	conn.RemoveSession(testConn.Sessions[0])
+
+	if conn.SessionCount() != len(testConn.Sessions)-1 {
+		t.Errorf("Session not removed expectedly: %d, %v", conn.SessionCount(), conn.Sessions)
+	}
+
+	for i := 1; i <= len(testConn.Sessions); i++ {
+		sess, err := testConn.GetSessionByTEID(uint32(i), dummyAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		lastDigit := strconv.Itoa(i)
+		if string(sess.IMSI[14]) != lastDigit {
+			t.Errorf("Got wrong session at %d, %s", i, sess.IMSI)
+		}
+	}
+}
+
+func TestRemoveSessionByIMSI(t *testing.T) {
+	conn := *testConn // copy testConn
+	conn.RemoveSessionByIMSI("001011234567891")
+
+	if conn.SessionCount() != len(testConn.Sessions)-1 {
+		t.Errorf("Session not removed expectedly: %d, %v", conn.SessionCount(), conn.Sessions)
+	}
+
+	for i := 1; i <= len(testConn.Sessions); i++ {
+		sess, err := testConn.GetSessionByTEID(uint32(i), dummyAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		lastDigit := strconv.Itoa(i)
+		if string(sess.IMSI[14]) != lastDigit {
+			t.Errorf("Got wrong session at %d, %s", i, sess.IMSI)
+		}
+	}
+}
+
+func TestSessionCount(t *testing.T) {
+	if want, got := testConn.SessionCount(), len(testConn.Sessions); want != got {
+		t.Errorf("SessionCount is invalid. want: %d, got: %d", want, got)
 	}
 }

--- a/v2/session.go
+++ b/v2/session.go
@@ -176,7 +176,7 @@ func (s *Session) RemoveBearerByEBI(ebi uint8) {
 	s.bearerMap.delete(name)
 }
 
-// GetDefaultBearer returns the pointer to default bearer.
+// GetDefaultBearer returns the default bearer.
 func (s *Session) GetDefaultBearer() *Bearer {
 	// it is not expected that the default bearer cannot be found.
 	bearer, ok := s.bearerMap.load("default")
@@ -221,7 +221,8 @@ func (s *Session) LookupBearerByEBI(ebi uint8) (*Bearer, error) {
 	return bearer, nil
 }
 
-// LookupBearerNameByEBI looks up name of Bearer by EBI.
+// LookupBearerNameByEBI looks up name of Bearer by EBI and returns
+// its name.
 func (s *Session) LookupBearerNameByEBI(ebi uint8) (string, error) {
 	var name string
 	s.bearerMap.rangeWithFunc(func(n, br interface{}) bool {
@@ -240,9 +241,9 @@ func (s *Session) LookupBearerNameByEBI(ebi uint8) (string, error) {
 	return name, nil
 }
 
-// LookupEBIByName returns EBI associated with Name given.
+// LookupEBIByName returns EBI associated with name.
 //
-// If no EBI found, it returns 0(invalid value for EBI).
+// If no EBI found, it returns 0(=invalid value for EBI).
 func (s *Session) LookupEBIByName(name string) uint8 {
 	if br, ok := s.bearerMap.load(name); ok {
 		return br.EBI
@@ -251,7 +252,7 @@ func (s *Session) LookupEBIByName(name string) uint8 {
 	return 0
 }
 
-// LookupEBIByTEID returns EBI associated with TEID given.
+// LookupEBIByTEID returns EBI associated with TEID.
 //
 // If no EBI found, it returns 0(=invalid value for EBI).
 func (s *Session) LookupEBIByTEID(teid uint32) uint8 {


### PR DESCRIPTION
* store peer nodes' address as a string to avoid calling String() every time looking up Session by TEID

https://gist.github.com/wmnsk/1de79b7cc1852c3020596f5f0f3a04fb

```
BenchmarkAddrComparisonString1-2         4453245               241 ns/op
BenchmarkAddrComparisonString2-2        360841701                3.17 ns/op
BenchmarkAddrComparisonBytes-2          286502511                4.12 ns/op
BenchmarkAddrComparisonReflect-2          639075              1600 ns/op
```

* ... to be updated?