### PR TITLE
Context-based conn handling for GTPv1-U

### DIFF
--- a/examples/gw-tester/pgw/main.go
+++ b/examples/gw-tester/pgw/main.go
@@ -12,9 +12,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-
-	v2 "github.com/wmnsk/go-gtp/v2"
-	"github.com/wmnsk/go-gtp/v2/messages"
 )
 
 func main() {
@@ -34,13 +31,6 @@ func main() {
 		return
 	}
 	defer pgw.close()
-	log.Printf("Started serving on %s", pgw.cConn.LocalAddr())
-
-	// register handlers for ALL the messages you expect remote endpoint to send.
-	pgw.cConn.AddHandlers(map[uint8]v2.HandlerFunc{
-		messages.MsgTypeCreateSessionRequest: pgw.handleCreateSessionRequest,
-		messages.MsgTypeDeleteSessionRequest: pgw.handleDeleteSessionRequest,
-	})
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGHUP)

--- a/examples/gw-tester/sgw/main.go
+++ b/examples/gw-tester/sgw/main.go
@@ -12,9 +12,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-
-	v2 "github.com/wmnsk/go-gtp/v2"
-	"github.com/wmnsk/go-gtp/v2/messages"
 )
 
 func main() {
@@ -33,19 +30,6 @@ func main() {
 		log.Printf("failed to initialize SGW: %s", err)
 	}
 	defer sgw.close()
-
-	// register handlers for ALL the messages you expect remote endpoint to send.
-	sgw.s11Conn.AddHandlers(map[uint8]v2.HandlerFunc{
-		messages.MsgTypeCreateSessionRequest: sgw.handleCreateSessionRequest,
-		messages.MsgTypeModifyBearerRequest:  sgw.handleModifyBearerRequest,
-		messages.MsgTypeDeleteSessionRequest: sgw.handleDeleteSessionRequest,
-		messages.MsgTypeDeleteBearerResponse: sgw.handleDeleteBearerResponse,
-	})
-	sgw.s5cConn.AddHandlers(map[uint8]v2.HandlerFunc{
-		messages.MsgTypeCreateSessionResponse: sgw.handleCreateSessionResponse,
-		messages.MsgTypeDeleteSessionResponse: sgw.handleDeleteSessionResponse,
-		messages.MsgTypeDeleteBearerRequest:   sgw.handleDeleteBearerRequest,
-	})
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGHUP)

--- a/examples/mme/mock.go
+++ b/examples/mme/mock.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"strings"
 	"time"
@@ -137,7 +136,7 @@ var (
 )
 
 type mockUEeNB struct {
-	laddr, raddr net.Addr
+	raddr net.Addr
 
 	subscriberIP string
 	teidOut      uint32
@@ -145,21 +144,6 @@ type mockUEeNB struct {
 }
 
 func (m mockUEeNB) run(errCh chan error) {
-	if uConn == nil {
-		// Listen on eNB S1-U interface.
-		enbUPlaneAddr, err := net.ResolveUDPAddr("udp", *s1enb)
-		if err != nil {
-			log.Fatal(err)
-		}
-		m.laddr = enbUPlaneAddr
-
-		uConn, err = v1.ListenAndServeUPlane(m.laddr, 0, errCh)
-		if err != nil {
-			errCh <- err
-			return
-		}
-	}
-
 	go func(teid uint32, payload []byte, raddr net.Addr) {
 		for {
 			copy(payload[12:16], net.ParseIP(m.subscriberIP).To4())

--- a/examples/pgw/pgw.go
+++ b/examples/pgw/pgw.go
@@ -204,18 +204,6 @@ func handleCreateSessionRequest(c *v2.Conn, sgwAddr net.Addr, msg messages.Messa
 	}
 	c.AddSession(session)
 
-	if uConn == nil {
-		laddr, err := net.ResolveUDPAddr("udp", *s5u)
-		if err != nil {
-			return err
-		}
-		uConn, err = v1.ListenAndServeUPlane(laddr, 0, errCh)
-		if err != nil {
-			return err
-		}
-	}
-	loggerCh <- fmt.Sprintf("Started listening on %s", uConn.LocalAddr())
-
 	go func() {
 		buf := make([]byte, 1500)
 		for {

--- a/v1/logger.go
+++ b/v1/logger.go
@@ -1,0 +1,69 @@
+// Copyright 2019 go-gtp authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package v1
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"sync"
+)
+
+var (
+	logger = log.New(os.Stderr, "", log.LstdFlags)
+	logMu  sync.Mutex
+)
+
+// SetLogger replaces the standard logger with arbitrary *log.Logger.
+//
+// This package prints just informational logs from goroutines working background
+// that might help developers test the program but can be ignored safely. More
+// important ones that needs any action by caller would be returned as errors.
+func SetLogger(l *log.Logger) {
+	if l == nil {
+		log.Println("Don't pass nil to SetLogger: use DisableLogging instead.")
+	}
+
+	setLogger(l)
+}
+
+// EnableLogging enables the logging from the package.
+// If l is nil, it uses default logger provided by the package.
+// Logging is enabled by default.
+//
+// See also: SetLogger.
+func EnableLogging(l *log.Logger) {
+	logMu.Lock()
+	defer logMu.Unlock()
+
+	setLogger(l)
+}
+
+// DisableLogging disables the logging from the package.
+// Logging is enabled by default.
+func DisableLogging() {
+	logMu.Lock()
+	defer logMu.Unlock()
+
+	logger.SetOutput(ioutil.Discard)
+}
+
+func setLogger(l *log.Logger) {
+	if l == nil {
+		l = log.New(os.Stderr, "", log.LstdFlags)
+	}
+
+	logMu.Lock()
+	defer logMu.Unlock()
+
+	logger = l
+}
+
+func logf(format string, v ...interface{}) {
+	logMu.Lock()
+	defer logMu.Unlock()
+
+	logger.Printf(format, v...)
+}

--- a/v1/relay_test.go
+++ b/v1/relay_test.go
@@ -25,14 +25,14 @@ func TestRelay(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	leftConn := v1.NewUPlaneConn(leftAddr, 0)
+	leftConn := v1.NewUPlaneConn(leftAddr)
 	go func() {
 		if err := leftConn.ListenAndServe(ctx); err != nil {
 			t.Fatal(err)
 		}
 	}()
 
-	rightConn := v1.NewUPlaneConn(rightAddr, 0)
+	rightConn := v1.NewUPlaneConn(rightAddr)
 	go func() {
 		if err := rightConn.ListenAndServe(ctx); err != nil {
 			t.Fatal(err)

--- a/v1/relay_test.go
+++ b/v1/relay_test.go
@@ -28,14 +28,16 @@ func TestRelay(t *testing.T) {
 	leftConn := v1.NewUPlaneConn(leftAddr)
 	go func() {
 		if err := leftConn.ListenAndServe(ctx); err != nil {
-			t.Fatal(err)
+			t.Errorf("failed to listen on %s: %s", leftConn.LocalAddr(), err)
+			return
 		}
 	}()
 
 	rightConn := v1.NewUPlaneConn(rightAddr)
 	go func() {
 		if err := rightConn.ListenAndServe(ctx); err != nil {
-			t.Fatal(err)
+			t.Errorf("failed to listen on %s: %s", rightConn.LocalAddr(), err)
+			return
 		}
 	}()
 

--- a/v1/tunnel_linux.go
+++ b/v1/tunnel_linux.go
@@ -11,6 +11,71 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+// Role is a role for Kernel GTP-U.
+type Role int
+
+// Role definitions.
+const (
+	RoleGGSN Role = iota
+	RoleSGSN
+)
+
+// EnableKernelGTP enables Linux Kernel GTP-U.
+// Note that this removes all the existing userland tunnels, and cannot be disabled while
+// the program is working (at least at this moment).
+//
+// Using Kernel GTP-U is much more performant than userland, but requires root privilege.
+// After enabled, users should add tunnels by AddTunnel func, and also add appropriate
+// routing entries. For handling downlink traffic on P-GW, for example;
+//
+//  ip route add <UE's IP> dev <devname> table <table ID>
+//  ip rule add from <SGi side of I/F> lookup <table ID>
+//
+// This let the traffic from SGi side of network I/F to be forwarded to GTP device,
+// and if the UE's IP is known to Kernel GTP-U(by AddTunnel), it is encapsulated and
+// forwarded to the peer(S-GW, in this case).
+//
+// Please see the examples/gw-tester for how each node handles routing from the program.
+func (u *UPlaneConn) EnableKernelGTP(devname string, role Role) error {
+	if u.kernGTPEnabled {
+		return nil
+	}
+
+	f, err := u.pktConn.(*net.UDPConn).File()
+	if err != nil {
+		return errors.Wrapf(err, "failed to retrieve file from conn")
+	}
+
+	u.GTPLink = &netlink.GTP{
+		LinkAttrs: netlink.LinkAttrs{
+			Name: devname,
+		},
+		FD1:  int(f.Fd()),
+		Role: int(role),
+	}
+
+	if err := netlink.LinkAdd(u.GTPLink); err != nil {
+		return errors.Wrapf(err, "failed to add device: %s", u.GTPLink.Name)
+	}
+	if err := netlink.LinkSetUp(u.GTPLink); err != nil {
+		return errors.Wrapf(err, "failed to setup device: %s", u.GTPLink.Name)
+	}
+	if err := netlink.LinkSetMTU(u.GTPLink, 1500); err != nil {
+		return errors.Wrapf(err, "failed to set MTU for device: %s", u.GTPLink.Name)
+	}
+
+	u.kernGTPEnabled = true
+
+	// remove relayed userland tunnels if exists
+	if len(u.relayMap) != 0 {
+		u.mu.Lock()
+		u.relayMap = nil
+		u.mu.Unlock()
+	}
+
+	return nil
+}
+
 // AddTunnel adds a GTP-U tunnel with Linux Kernel GTP-U via netlink.
 func (u *UPlaneConn) AddTunnel(peerIP, msIP net.IP, otei, itei uint32) error {
 	if !u.kernGTPEnabled {

--- a/v1/tunnel_linux.go
+++ b/v1/tunnel_linux.go
@@ -37,8 +37,12 @@ const (
 //
 // Please see the examples/gw-tester for how each node handles routing from the program.
 func (u *UPlaneConn) EnableKernelGTP(devname string, role Role) error {
-	if u.kernGTPEnabled {
-		return nil
+	if u.pktConn == nil {
+		var err error
+		u.pktConn, err = net.ListenPacket(u.laddr.Network(), u.laddr.String())
+		if err != nil {
+			return err
+		}
 	}
 
 	f, err := u.pktConn.(*net.UDPConn).File()
@@ -63,7 +67,6 @@ func (u *UPlaneConn) EnableKernelGTP(devname string, role Role) error {
 	if err := netlink.LinkSetMTU(u.GTPLink, 1500); err != nil {
 		return errors.Wrapf(err, "failed to set MTU for device: %s", u.GTPLink.Name)
 	}
-
 	u.kernGTPEnabled = true
 
 	// remove relayed userland tunnels if exists

--- a/v1/u-conn.go
+++ b/v1/u-conn.go
@@ -7,7 +7,6 @@ package v1
 import (
 	"context"
 	"encoding/binary"
-	"log"
 	"net"
 	"strings"
 	"sync"
@@ -118,7 +117,7 @@ func DialUPlane(ctx context.Context, laddr, raddr net.Addr, counter uint8) (*UPl
 
 	go func() {
 		if err := u.serve(ctx); err != nil {
-			log.Printf("fatal error on UPlaneConn %s: %s", u.LocalAddr(), err)
+			logf("fatal error on UPlaneConn %s: %s", u.LocalAddr(), err)
 			_ = u.Close()
 		}
 	}()
@@ -206,7 +205,7 @@ func DialUPlaneKernel(ctx context.Context, devname string, role Role, laddr, rad
 
 	go func() {
 		if err := u.serve(ctx); err != nil {
-			log.Printf("fatal error on UPlaneConn %s: %s", u.LocalAddr(), err)
+			logf("fatal error on UPlaneConn %s: %s", u.LocalAddr(), err)
 			_ = u.Close()
 		}
 	}()
@@ -322,7 +321,7 @@ func (u *UPlaneConn) serve(ctx context.Context) error {
 			binary.BigEndian.PutUint32(buf[4:8], peer.teid)
 			if _, err := peer.srcConn.WriteTo(buf, peer.addr); err != nil {
 				// should not stop serving with this error
-				log.Printf("error sending on UPlaneConn %s: %s", u.LocalAddr(), err)
+				logf("error sending on UPlaneConn %s: %s", u.LocalAddr(), err)
 			}
 			continue
 		}
@@ -334,7 +333,7 @@ func (u *UPlaneConn) serve(ctx context.Context) error {
 
 		if err := u.handleMessage(raddr, msg); err != nil {
 			// should not stop serving with this error
-			log.Printf("error handling message on UPlaneConn %s: %s", u.LocalAddr(), err)
+			logf("error handling message on UPlaneConn %s: %s", u.LocalAddr(), err)
 		}
 	}
 }
@@ -415,7 +414,7 @@ func (u *UPlaneConn) Close() error {
 
 	if u.kernGTPEnabled {
 		if err := netlink.LinkDel(u.GTPLink); err != nil {
-			log.Printf("error deleting GTPLink: %s", err)
+			logf("error deleting GTPLink: %s", err)
 		}
 	}
 

--- a/v1/u-conn.go
+++ b/v1/u-conn.go
@@ -43,7 +43,6 @@ type UPlaneConn struct {
 
 	tpduCh  chan *tpduSet
 	closeCh chan struct{}
-	errCh   chan error
 
 	relayMap map[uint32]*peer
 
@@ -496,7 +495,7 @@ func (u *UPlaneConn) handleMessage(senderAddr net.Addr, msg messages.Message) er
 	}
 	go func() {
 		if err := handle(u, senderAddr, msg); err != nil {
-			u.errCh <- err
+			logf("failed to handle message %s: %s", msg, err)
 		}
 	}()
 

--- a/v1/u-conn.go
+++ b/v1/u-conn.go
@@ -312,7 +312,7 @@ func (u *UPlaneConn) serve(ctx context.Context) error {
 
 			// just use original packet not to get it slow.
 			binary.BigEndian.PutUint32(buf[4:8], peer.teid)
-			if _, err := peer.srcConn.WriteTo(buf, peer.addr); err != nil {
+			if _, err := peer.srcConn.WriteTo(buf[:n], peer.addr); err != nil {
 				// should not stop serving with this error
 				logf("error sending on UPlaneConn %s: %s", u.LocalAddr(), err)
 			}

--- a/v1/u-conn_test.go
+++ b/v1/u-conn_test.go
@@ -32,7 +32,7 @@ func setup(ctx context.Context) (cliConn, srvConn *v1.UPlaneConn, err error) {
 	}
 
 	go func() {
-		srvConn = v1.NewUPlaneConn(srvAddr, 0)
+		srvConn = v1.NewUPlaneConn(srvAddr)
 		if err := srvConn.ListenAndServe(ctx); err != nil {
 			return
 		}
@@ -40,7 +40,7 @@ func setup(ctx context.Context) (cliConn, srvConn *v1.UPlaneConn, err error) {
 
 	// XXX - waiting for server to be well-prepared, should consider better way.
 	time.Sleep(1 * time.Second)
-	cliConn, err = v1.DialUPlane(ctx, cliAddr, srvAddr, 0)
+	cliConn, err = v1.DialUPlane(ctx, cliAddr, srvAddr)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
**This contains big changes of exported API**

- [x] Added context as a first param of the APIs that launches background goroutines.
- [x] Removed `errCh`-based error notifications. Now only the critical errors are returned from package, and the minor ones are just logged.
- [x] Added logger implementation. Users can set any `log.Logger` with `v1.SetLogger`.
- [x] Updated documents
- [x] Update examples
