### PR TITLE
Session add/lookup using sync map

### DIFF
--- a/examples/mme/main.go
+++ b/examples/mme/main.go
@@ -203,7 +203,7 @@ func main() {
 			}()
 		// delete all the sessions after 30 seconds
 		case <-time.After(30 * time.Second):
-			for _, sess := range s11Conn.Sessions {
+			for _, sess := range s11Conn.Sessions() {
 				teid, err := sess.GetTEID(v2.IFTypeS11S4SGWGTPC)
 				if err != nil {
 					errCh <- v2.ErrTEIDNotFound

--- a/examples/pgw/main.go
+++ b/examples/pgw/main.go
@@ -92,7 +92,7 @@ func main() {
 			log.Printf("Warning: %s", err)
 		case <-time.After(10 * time.Second):
 			var activeIMSIs []string
-			for _, sess := range s5cConn.Sessions {
+			for _, sess := range s5cConn.Sessions() {
 				if !sess.IsActive() {
 					continue
 				}

--- a/examples/sgw/main.go
+++ b/examples/sgw/main.go
@@ -118,7 +118,7 @@ func (s *sGateway) run() error {
 			log.Printf("Warning: %s", errors.WithStack(err))
 		case <-time.After(10 * time.Second):
 			var activeIMSIs []string
-			for _, sess := range s.s11Conn.Sessions {
+			for _, sess := range s.s11Conn.Sessions() {
 				if !sess.IsActive() {
 					continue
 				}

--- a/v2/conn.go
+++ b/v2/conn.go
@@ -811,11 +811,10 @@ func (i *imsiSessionMap) store(imsi string, session *Session) {
 
 func (i *imsiSessionMap) load(imsi string) (*Session, bool) {
 	session, ok := i.syncMap.Load(imsi)
-	if !ok {
-		return nil, false
+	if ok && session != nil {
+		return session.(*Session), true
 	}
-
-	return session.(*Session), true
+	return nil, ok
 }
 
 func (i *imsiSessionMap) delete(imsi string) {
@@ -845,11 +844,10 @@ func (t *teidSessionMap) tryStore(teid uint32, session *Session) bool {
 
 func (t *teidSessionMap) load(teid uint32) (*Session, bool) {
 	session, ok := t.syncMap.Load(teid)
-	if !ok {
-		return nil, false
+	if ok && session != nil {
+		return session.(*Session), true
 	}
-
-	return session.(*Session), true
+	return nil, ok
 }
 
 func (t *teidSessionMap) delete(teid uint32) {

--- a/v2/conn.go
+++ b/v2/conn.go
@@ -756,9 +756,8 @@ func generateRandomUint32() uint32 {
 
 // Bearers returns all the bearers registered in Session.
 func (c *Conn) Sessions() []*Session {
-
 	var ss []*Session
-	c.teidSessionMap.rangeWithFunc(func(k, v interface{}) bool {
+	c.imsiSessionMap.rangeWithFunc(func(k, v interface{}) bool {
 		ss = append(ss, v.(*Session))
 		return true
 	})

--- a/v2/conn.go
+++ b/v2/conn.go
@@ -840,10 +840,7 @@ func (t *teidSessionMap) store(teid uint32, session *Session) {
 
 func (t *teidSessionMap) tryStore(teid uint32, session *Session) bool {
 	_, loaded := t.syncMap.LoadOrStore(teid, session)
-	if loaded {
-		return false
-	}
-	return true
+	return !loaded
 }
 
 func (t *teidSessionMap) load(teid uint32) (*Session, bool) {
@@ -857,8 +854,4 @@ func (t *teidSessionMap) load(teid uint32) (*Session, bool) {
 
 func (t *teidSessionMap) delete(teid uint32) {
 	t.syncMap.Delete(teid)
-}
-
-func (t *teidSessionMap) rangeWithFunc(fn func(teid, session interface{}) bool) {
-	t.syncMap.Range(fn)
 }

--- a/v2/helpers_test.go
+++ b/v2/helpers_test.go
@@ -67,14 +67,11 @@ func benchmarkAddSession(numExisitingSessions int, b *testing.B) {
 	}
 }
 
-func BenchmarkAddSessionExist0(b *testing.B)   { benchmarkAddSession(0, b) }
-func BenchmarkAddSessionExist100(b *testing.B) { benchmarkAddSession(1e2, b) }
-func BenchmarkAddSessionExist1K(b *testing.B)  { benchmarkAddSession(1e3, b) }
-func BenchmarkAddSessionExist10K(b *testing.B) { benchmarkAddSession(1e4, b) }
-
-// TODO: Uncomment after session lookup is changed as currently it takes too long
-// func BenchmarkAddSessionExist100K(b *testing.B) { benchmarkAddSession(1e5, b) }
-// func BenchmarkAddSessionExist1M(b *testing.B)   { benchmarkAddSession(1e6, b) }
+func BenchmarkAddSessionExist0(b *testing.B)    { benchmarkAddSession(0, b) }
+func BenchmarkAddSessionExist100(b *testing.B)  { benchmarkAddSession(1e2, b) }
+func BenchmarkAddSessionExist1K(b *testing.B)   { benchmarkAddSession(1e3, b) }
+func BenchmarkAddSessionExist10K(b *testing.B)  { benchmarkAddSession(1e4, b) }
+func BenchmarkAddSessionExist100K(b *testing.B) { benchmarkAddSession(1e5, b) }
 
 func TestGetSessionByTEID(t *testing.T) {
 	for i := 1; i <= testConn.SessionCount(); i++ {


### PR DESCRIPTION
This PR addresses #62 

The number of places session lookup touches is quite a bit. Things i am fuzzy around -

- There is nothing to connect Session and the Conn, so we have to pass TEIDSessionMap OR we can add to Session struct (needed in NewSession)
- TEID being unique per Conn (this PR) vs Conn+IfType (existing impl)
- Need for mutexes around sync.Map
- Test changes made