### PR TITLE
Refactor benchmark code to be a loop

### DIFF
--- a/v2/helpers_test.go
+++ b/v2/helpers_test.go
@@ -2,6 +2,7 @@ package v2_test
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"strconv"
 	"testing"
@@ -55,23 +56,21 @@ func TestGetSessionByIMSI_GetTEID(t *testing.T) {
 	}
 }
 
-func benchmarkAddSession(numExisitingSessions int, b *testing.B) {
-	benchConn := v2.NewConn(dummyAddr, 0)
-	for i := 0; i < numExisitingSessions; i++ {
-		imsi := fmt.Sprintf("%015d", i)
-		benchConn.AddSession(v2.NewSession(dummyAddr, &v2.Subscriber{IMSI: imsi}))
-	}
-	b.ResetTimer()
-	for i := 1; i <= b.N; i++ {
-		benchConn.AddSession(v2.NewSession(dummyAddr, &v2.Subscriber{IMSI: "001011234567891"}))
+func BenchmarkAddSession(b *testing.B) {
+	for k := 0.; k < 6; k++ {
+		existingSessions := int(math.Pow(10, k))
+		benchConn := v2.NewConn(dummyAddr, 0)
+		for i := 0; i < existingSessions; i++ {
+			imsi := fmt.Sprintf("%015d", i)
+			benchConn.AddSession(v2.NewSession(dummyAddr, &v2.Subscriber{IMSI: imsi}))
+		}
+		b.Run(fmt.Sprintf("%d", existingSessions), func(b *testing.B) {
+			for i := 1; i <= b.N; i++ {
+				benchConn.AddSession(v2.NewSession(dummyAddr, &v2.Subscriber{IMSI: "001011234567891"}))
+			}
+		})
 	}
 }
-
-func BenchmarkAddSessionExist0(b *testing.B)    { benchmarkAddSession(0, b) }
-func BenchmarkAddSessionExist100(b *testing.B)  { benchmarkAddSession(1e2, b) }
-func BenchmarkAddSessionExist1K(b *testing.B)   { benchmarkAddSession(1e3, b) }
-func BenchmarkAddSessionExist10K(b *testing.B)  { benchmarkAddSession(1e4, b) }
-func BenchmarkAddSessionExist100K(b *testing.B) { benchmarkAddSession(1e5, b) }
 
 func TestGetSessionByTEID(t *testing.T) {
 	for i := 1; i <= testConn.SessionCount(); i++ {


### PR DESCRIPTION
Using the concept of sub-benchmarks we can collapse all the cases into a for loop.

```
goos: linux
goarch: amd64
pkg: github.com/wmnsk/go-gtp/v2
BenchmarkAddSession/1-88  	   97202	     12358 ns/op	   17240 B/op	      20 allocs/op
BenchmarkAddSession/10-88 	   95139	     12411 ns/op	   17240 B/op	      20 allocs/op
BenchmarkAddSession/100-88         	   92438	     12841 ns/op	   17240 B/op	      20 allocs/op
BenchmarkAddSession/1000-88        	   99679	     10672 ns/op	   17240 B/op	      20 allocs/op
BenchmarkAddSession/10000-88       	  194298	      9588 ns/op	   17240 B/op	      20 allocs/op
BenchmarkAddSession/100000-88      	  306838	      7576 ns/op	   17240 B/op	      20 allocs/op
PASS
ok  	github.com/wmnsk/go-gtp/v2	12.070s
Success: Benchmarks passed.
```

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>