### PR TITLE
Fix: Delete only if teid and session both match

### DIFF
--- a/v2/conn.go
+++ b/v2/conn.go
@@ -696,7 +696,9 @@ func (c *Conn) RemoveSession(session *Session) {
 	c.imsiSessionMap.delete(session.IMSI)
 	session.teidMap.rangeWithFunc(func(k, v interface{}) bool {
 		teid := v.(uint32)
-		c.teidSessionMap.delete(teid)
+		if s, ok := c.teidSessionMap.load(teid); ok && s == session {
+			c.teidSessionMap.delete(teid)
+		}
 		return true
 	})
 }


### PR DESCRIPTION
Fixes: #72

Delete TEIDSessionMap only if teid and session both match

Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>