### PR TITLE
Fix termination of U-Plane connection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-1.11
-      - test-1.12
+      - test-1.13
+      - test-1.14
 jobs:
-  test-1.11:
+  test-1.13:
     docker:
-      - image: 'circleci/golang:1.11'
+      - image: 'circleci/golang:1.13'
     steps: &ref_0
       - checkout
       - restore_cache:
@@ -21,7 +21,7 @@ jobs:
           key: go-mod-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
-  test-1.12:
+  test-1.14:
     docker:
-      - image: 'circleci/golang:1.12'
+      - image: 'circleci/golang:1.14'
     steps: *ref_0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ jobs:
   test-linux:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x]
+        go-version: [1.13.x, 1.14.x]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -20,7 +20,7 @@ jobs:
   test-macos:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x]
+        go-version: [1.13.x, 1.14.x]
     runs-on: macos-latest
     steps:
       - name: Install Go
@@ -41,7 +41,7 @@ jobs:
   # test-windows:
   #   strategy:
   #     matrix:
-  #       go-version: [1.12.x, 1.13.x]
+  #       go-version: [1.13.x, 1.14.x]
   #   runs-on: windows-latest
   #   steps:
   #   - name: Install Go


### PR DESCRIPTION
Close() of the underlying connection(net.PacketConn) fails(blocks forever) when Linux Kernel GTP-U is enabled. This is just a quick workaround for that to terminate the program gracefully.