### PR TITLE
Replaced addr with sibling which is guaranteed to exist

### DIFF
--- a/examples/mme/main.go
+++ b/examples/mme/main.go
@@ -110,7 +110,7 @@ func main() {
 			return
 		}
 	}()
-	log.Printf("Started listening on %s", uConn.LocalAddr())
+	log.Printf("Started listening on %s", enbUPlaneAddr)
 
 	// here you should wait for UEs to come attaching to your network.
 	// in this example, the following five subscribers are to be attached.


### PR DESCRIPTION
This will avoid race condition as pktConn used by uConn.LocalAddr() is only created in goroutine - app might fail with segfault due to null ptr dereference (which regularly happens on my machine)