### PR TITLE
fixed examples (no cancel for ctx + added ports for ifaces)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+examples/mme/mme
+examples/pgw/pgw
+examples/sgw/sgw

--- a/examples/sgw/main.go
+++ b/examples/sgw/main.go
@@ -62,8 +62,7 @@ func newSGW(s11, s5c, s1u, s5u net.Addr) (*sGateway, error) {
 		errCh:    make(chan error),
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := context.Background()
 
 	var err error
 	s.s11Conn = v2.NewConn(s11, v2.IFTypeS11S4SGWGTPC, 0)

--- a/examples/sgw/s11.go
+++ b/examples/sgw/s11.go
@@ -53,7 +53,7 @@ func handleCreateSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 		return &v2.RequiredIEMissingError{Type: ies.FullyQualifiedTEID}
 	}
 
-	laddr, err := net.ResolveUDPAddr("udp", *s5c)
+	laddr, err := net.ResolveUDPAddr("udp", *s5c+v2.GTPCPort)
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ func handleCreateSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 		return &v2.RequiredIEMissingError{Type: ies.RATType}
 	}
 
-	s11IP, _, err := net.SplitHostPort(*s11)
+	s11IP, _, err := net.SplitHostPort(*s11 + v2.GTPCPort)
 	if err != nil {
 		return errors.Wrap(err, "failed to get IP for S11")
 	}
@@ -141,7 +141,7 @@ func handleCreateSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 	s11Conn.RegisterSession(s11sgwTEID, s11Session)
 
 	s5cIP := laddr.IP.String()
-	s5uIP, _, err := net.SplitHostPort(*s5u)
+	s5uIP, _, err := net.SplitHostPort(*s5u + v2.GTPCPort)
 	if err != nil {
 		return err
 	}
@@ -205,7 +205,7 @@ func handleCreateSessionRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages
 		return &v2.UnexpectedTypeError{Msg: message}
 	}
 	// if everything in CreateSessionResponse seems OK, relay it to MME.
-	s1uIP, _, err := net.SplitHostPort(*s1u)
+	s1uIP, _, err := net.SplitHostPort(*s1u + v2.GTPCPort)
 	if err != nil {
 		return errors.Wrap(err, "failed to get IP for S1-U")
 	}
@@ -306,7 +306,7 @@ func handleModifyBearerRequest(s11Conn *v2.Conn, mmeAddr net.Addr, msg messages.
 		return err
 	}
 
-	s1uIP, _, err := net.SplitHostPort(*s1u)
+	s1uIP, _, err := net.SplitHostPort(*s1u + v2.GTPCPort)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1) There is no use case for cancelable context in test app ( closes https://github.com/wmnsk/go-gtp/issues/86 )

2) Added ports across the code since it was causing errors preventing example apps from performing expected call sequence. Now test flow works. (have not created github issue for that)
