### PR TITLE
added missing GTPv1 causes

### DIFF
--- a/v1/constants.go
+++ b/v1/constants.go
@@ -61,6 +61,23 @@ const (
 	ResCauseSemanticErrorInTheTFTOperation
 	ResCauseSyntacticErrorInTheTFTOperation
 	ResCauseSemanticErrorsInPacketFilter
+	ResCauseSyntacticErrorsInPacketFilter
+	ResCauseMissingOrUnknownAPN
+	ResCauseUnknownPDPAddressOrPDPType
+	ResCausePDPContextWithoutTFTAlreadyActivated
+	ResCauseAPNAccessDeniedNoSubscription
+	ResCauseAPNRestrictionTypeIncompatibilityWithCurrentlyActivePDPContexts
+	ResCauseMSMBMSCapabilitiesInsufficient
+	ResCauseInvalidCorrelationID
+	ResCauseMBMSBearerContextSuperseded
+	ResCauseBearerControlModeViolation
+	ResCauseCollisionWithNetworkInitiatedRequest
+	ResCauseAPNCongestion
+	ResCauseBearerHandlingNotSupported
+	ResCauseTargetAccessRestrictedForTheSubscriber
+	ResCauseUEIsTemporarilyNotReachableDueToPowerSaving
+	ResCauseRelocationFailureDueToNASMessageRedirection
+	// 234-255: for future use / reserved for prime.
 )
 
 // SelectionMode definitions.


### PR DESCRIPTION
Some causes were absent in GTP v1. Added missing according to specs https://www.developingsolutions.com/reference-guides/gtp-cause-codes/