### PR TITLE
Enable Error Indication by default

### DIFF
--- a/gtpv1/u-conn_test.go
+++ b/gtpv1/u-conn_test.go
@@ -33,6 +33,7 @@ func setup(ctx context.Context) (cliConn, srvConn *v1.UPlaneConn, err error) {
 
 	go func() {
 		srvConn = v1.NewUPlaneConn(srvAddr)
+		srvConn.DisableErrorIndication()
 		if err := srvConn.ListenAndServe(ctx); err != nil {
 			return
 		}
@@ -44,6 +45,7 @@ func setup(ctx context.Context) (cliConn, srvConn *v1.UPlaneConn, err error) {
 	if err != nil {
 		return nil, nil, err
 	}
+	cliConn.DisableErrorIndication()
 
 	return cliConn, srvConn, nil
 }


### PR DESCRIPTION
Now gtpv1.UPlaneConn responds to T-PDU with unknown TEID with Error Indication, which 3GPP tells to do.

This can be disabled by calling DisableErrorIndication(in that case the T-PDU is passed to user who calls ReadFromGTP) or replace handler with custom one using AddHandler.