### PR TITLE
Return errors from handleMessage()

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ workflows:
   version: 2
   test:
     jobs:
-      - test-1.13
       - test-1.14
+      - test-1.15
 jobs:
-  test-1.13:
+  test-1.14:
     docker:
-      - image: 'circleci/golang:1.13'
+      - image: "circleci/golang:1.14"
     steps: &ref_0
       - checkout
       - restore_cache:
@@ -21,7 +21,7 @@ jobs:
           key: go-mod-{{ checksum "go.sum" }}
           paths:
             - "/go/pkg/mod"
-  test-1.14:
+  test-1.15:
     docker:
-      - image: 'circleci/golang:1.14'
+      - image: "circleci/golang:1.15"
     steps: *ref_0

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,7 @@ jobs:
   test-linux:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.14.x, 1.15.x]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -20,7 +20,7 @@ jobs:
   test-macos:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.14.x, 1.15.x]
     runs-on: macos-latest
     steps:
       - name: Install Go
@@ -41,7 +41,7 @@ jobs:
   # test-windows:
   #   strategy:
   #     matrix:
-  #       go-version: [1.13.x, 1.14.x]
+  #       go-version: [1.14.x, 1.15.x]
   #   runs-on: windows-latest
   #   steps:
   #   - name: Install Go

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Package gtp provides simple and painless handling of GTP(GPRS Tunneling Protocol), implemented in the Go Programming Language.
 
 [![CircleCI](https://circleci.com/gh/wmnsk/go-gtp.svg?style=shield)](https://circleci.com/gh/wmnsk/go-gtp)
-[![GolangCI](https://golangci.com/badges/github.com/wmnsk/go-gtp.svg)](https://golangci.com/r/github.com/wmnsk/go-gtp)
 [![GoDoc](https://godoc.org/github.com/wmnsk/go-gtp?status.svg)](https://godoc.org/github.com/wmnsk/go-gtp)
 [![GitHub](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/wmnsk/go-gtp/blob/master/LICENSE)
 
@@ -20,19 +19,13 @@ Package gtp provides simple and painless handling of GTP(GPRS Tunneling Protocol
 
 ### Prerequisites
 
-The following packages should be installed before starting.  
+go-gtp supports Go Modules. Just run go mod tidy in your project's directory to collect the required packages automatically.
 
-```shell-session
-go get -u github.com/pkg/errors
-go get -u github.com/google/go-cmp/cmp
-go get -u github.com/pascaldekloe/goe/verify
+```
+go mod tidy
 ```
 
-If you use Go 1.11+, you can also use Go Modules.
-
-```shell-session
-GO111MODULE=on go [test | build | run | etc...]
-```
+_This project follows [the Release Policy of Go](https://golang.org/doc/devel/release.html#policy)._
 
 ### Running examples
 

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/wmnsk/go-gtp
 
-go 1.14
+go 1.15
 
 require (
 	github.com/golang/protobuf v1.4.2
-	github.com/google/go-cmp v0.5.1
+	github.com/google/go-cmp v0.5.2
 	github.com/pascaldekloe/goe v0.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/vishvananda/netlink v1.1.0
@@ -12,5 +12,5 @@ require (
 	golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5 // indirect
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20200210034751-acff78025515 // indirect
-	google.golang.org/grpc v1.30.0
+	google.golang.org/grpc v1.30.1
 )

--- a/go.sum
+++ b/go.sum
@@ -28,10 +28,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
-github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
-github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -84,8 +82,8 @@ google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZi
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.30.0 h1:M5a8xTlYTxwMn5ZFkwhRabsygDY5G8TYLyQDBxJNAxE=
-google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
+google.golang.org/grpc v1.30.1 h1:oJTcovwKSu7V3TaBKd0/AXOuJVHjTdGTutbMHIOgVEQ=
+google.golang.org/grpc v1.30.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/gtpv1/errors.go
+++ b/gtpv1/errors.go
@@ -10,12 +10,6 @@ import (
 )
 
 var (
-	// ErrNoHandlersFound indicates that the handler func is not registered in *Conn
-	// for the incoming GTPv2 message. In usual cases this error should not be taken
-	// as fatal, as the other endpoint can make your program stop working just by
-	// sending unregistered message.
-	ErrNoHandlersFound = errors.New("no handlers found for incoming message, ignoring")
-
 	// ErrUnexpectedType indicates that the type of incoming message is not expected.
 	ErrUnexpectedType = errors.New("got unexpected type of message")
 
@@ -36,4 +30,17 @@ type ErrorIndicatedError struct {
 
 func (e *ErrorIndicatedError) Error() string {
 	return fmt.Sprintf("error received from %s, TEIDDataI: %#x", e.Peer, e.TEID)
+}
+
+// HandlerNotFoundError indicates that the handler func is not registered in *Conn
+// for the incoming GTPv2 message. In usual cases this error should not be taken
+// as fatal, as the other endpoint can make your program stop working just by
+// sending unregistered message.
+type HandlerNotFoundError struct {
+	MsgType string
+}
+
+//x Error returns violating message type to handle.
+func (e *HandlerNotFoundError) Error() string {
+	return fmt.Sprintf("no handlers found for incoming message: %s, ignoring", e.MsgType)
 }


### PR DESCRIPTION
The current code just logs if some errors happen in `handleMessage()` and does not return error. Since the handling of error should be handled by the caller, it now returns an error.
