### PR TITLE
Support decoding GTP messages in larger buffer

### DIFF
--- a/gtpv1/message/header.go
+++ b/gtpv1/message/header.go
@@ -114,7 +114,7 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 		h.Payload = b[offset:]
 		return nil
 	}
-	if fixedHeaderSize+h.Length > uint16(offset) {
+	if fixedHeaderSize+h.Length >= uint16(offset) {
 		h.Payload = b[offset : fixedHeaderSize+h.Length]
 	} else {
 		return ErrInvalidLength

--- a/gtpv1/message/header.go
+++ b/gtpv1/message/header.go
@@ -114,10 +114,12 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 		h.Payload = b[offset:]
 		return nil
 	}
-	h.Payload = nil
 	if fixedHeaderSize+h.Length > uint16(offset) {
 		h.Payload = b[offset : fixedHeaderSize+h.Length]
+	} else {
+		return ErrInvalidLength
 	}
+
 	return nil
 }
 

--- a/gtpv1/message/header.go
+++ b/gtpv1/message/header.go
@@ -101,7 +101,7 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 		offset += 4
 	}
 
-	if int(h.Length)+8 != l {
+	if int(h.Length)+8 > l {
 		h.Payload = b[offset:]
 		return nil
 	}

--- a/gtpv1/message/header.go
+++ b/gtpv1/message/header.go
@@ -9,6 +9,12 @@ import (
 	"fmt"
 )
 
+const (
+	fixedHeaderSize = 8
+	// sequence number and padding size
+	seqSize = 4
+)
+
 // Header is a GTPv1 common header.
 type Header struct {
 	Flags          uint8
@@ -96,16 +102,22 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 	h.TEID = binary.BigEndian.Uint32(b[4:8])
 	offset += 4
 	if h.HasSequence() {
+		if h.Length < seqSize {
+			return ErrTooShortToParse
+		}
 		h.SequenceNumber = binary.BigEndian.Uint16(b[offset : offset+2])
 		// two bytes of padding before payload.
 		offset += 4
 	}
 
-	if int(h.Length)+8 > l {
+	if int(h.Length)+fixedHeaderSize > l {
 		h.Payload = b[offset:]
 		return nil
 	}
-	h.Payload = b[offset : 8+h.Length]
+	h.Payload = nil
+	if fixedHeaderSize+h.Length > uint16(offset) {
+		h.Payload = b[offset : fixedHeaderSize+h.Length]
+	}
 	return nil
 }
 

--- a/gtpv2/message/header.go
+++ b/gtpv2/message/header.go
@@ -15,8 +15,8 @@ const (
 	fixedHeaderSize  = 4
 	seqSpareSize     = 4
 	teidSize         = 4
-	noTeidHeaderSize = fixedHeaderSize + seqSpareSize
-	teidHeaderSize   = noTeidHeaderSize + teidSize
+	noTEIDHeaderSize = fixedHeaderSize + seqSpareSize
+	teidHeaderSize   = noTEIDHeaderSize + teidSize
 )
 
 // Header is a GTPv2 common header
@@ -122,11 +122,11 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 	h.Spare = b[7]
 
 	if int(h.Length)+fixedHeaderSize > l {
-		h.Payload = b[noTeidHeaderSize:]
+		h.Payload = b[noTEIDHeaderSize:]
 		return nil
 	}
-	if fixedHeaderSize+h.Length >= noTeidHeaderSize {
-		h.Payload = b[noTeidHeaderSize : fixedHeaderSize+h.Length]
+	if fixedHeaderSize+h.Length >= noTEIDHeaderSize {
+		h.Payload = b[noTEIDHeaderSize : fixedHeaderSize+h.Length]
 	} else {
 		return ErrInvalidLength
 	}

--- a/gtpv2/message/header.go
+++ b/gtpv2/message/header.go
@@ -11,6 +11,14 @@ import (
 	"github.com/wmnsk/go-gtp/utils"
 )
 
+const (
+	fixedHeaderSize  = 4
+	seqSpareSize     = 4
+	teidSize         = 4
+	noTeidHeaderSize = fixedHeaderSize + seqSpareSize
+	teidHeaderSize   = noTeidHeaderSize + teidSize
+)
+
 // Header is a GTPv2 common header
 type Header struct {
 	Flags          uint8
@@ -88,26 +96,38 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 	h.Flags = b[0]
 	h.Type = b[1]
 	h.Length = binary.BigEndian.Uint16(b[2:4])
+	if h.Length < seqSpareSize {
+		return ErrTooShortToParse
+	}
 	if h.HasTEID() {
+		if h.Length < seqSpareSize+teidSize {
+			return ErrTooShortToParse
+		}
 		h.TEID = binary.BigEndian.Uint32(b[4:8])
 		h.SequenceNumber = utils.Uint24To32(b[8:11])
 		h.Spare = b[11]
 
-		if int(h.Length)+12 > l {
-			h.Payload = b[12:]
+		if int(h.Length)+fixedHeaderSize > l {
+			h.Payload = b[teidHeaderSize:]
 			return nil
 		}
-		h.Payload = b[12 : 12+h.Length]
+		h.Payload = nil
+		if fixedHeaderSize+h.Length > teidHeaderSize {
+			h.Payload = b[teidHeaderSize : fixedHeaderSize+h.Length]
+		}
 		return nil
 	}
 	h.SequenceNumber = utils.Uint24To32(b[4:7])
 	h.Spare = b[7]
 
-	if int(h.Length)+8 > l {
-		h.Payload = b[8:]
+	if int(h.Length)+fixedHeaderSize > l {
+		h.Payload = b[noTeidHeaderSize:]
 		return nil
 	}
-	h.Payload = b[8 : 8+h.Length]
+	h.Payload = nil
+	if fixedHeaderSize+h.Length > noTeidHeaderSize {
+		h.Payload = b[noTeidHeaderSize : fixedHeaderSize+h.Length]
+	}
 
 	return nil
 }

--- a/gtpv2/message/header.go
+++ b/gtpv2/message/header.go
@@ -111,7 +111,7 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 			h.Payload = b[teidHeaderSize:]
 			return nil
 		}
-		if fixedHeaderSize+h.Length > teidHeaderSize {
+		if fixedHeaderSize+h.Length >= teidHeaderSize {
 			h.Payload = b[teidHeaderSize : fixedHeaderSize+h.Length]
 		} else {
 			return ErrInvalidLength
@@ -125,7 +125,7 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 		h.Payload = b[noTeidHeaderSize:]
 		return nil
 	}
-	if fixedHeaderSize+h.Length > noTeidHeaderSize {
+	if fixedHeaderSize+h.Length >= noTeidHeaderSize {
 		h.Payload = b[noTeidHeaderSize : fixedHeaderSize+h.Length]
 	} else {
 		return ErrInvalidLength

--- a/gtpv2/message/header.go
+++ b/gtpv2/message/header.go
@@ -111,9 +111,10 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 			h.Payload = b[teidHeaderSize:]
 			return nil
 		}
-		h.Payload = nil
 		if fixedHeaderSize+h.Length > teidHeaderSize {
 			h.Payload = b[teidHeaderSize : fixedHeaderSize+h.Length]
+		} else {
+			return ErrInvalidLength
 		}
 		return nil
 	}
@@ -124,9 +125,10 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 		h.Payload = b[noTeidHeaderSize:]
 		return nil
 	}
-	h.Payload = nil
 	if fixedHeaderSize+h.Length > noTeidHeaderSize {
 		h.Payload = b[noTeidHeaderSize : fixedHeaderSize+h.Length]
+	} else {
+		return ErrInvalidLength
 	}
 
 	return nil

--- a/gtpv2/message/header.go
+++ b/gtpv2/message/header.go
@@ -93,7 +93,7 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 		h.SequenceNumber = utils.Uint24To32(b[8:11])
 		h.Spare = b[11]
 
-		if int(h.Length)+12 != l {
+		if int(h.Length)+12 > l {
 			h.Payload = b[12:]
 			return nil
 		}
@@ -103,7 +103,7 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 	h.SequenceNumber = utils.Uint24To32(b[4:7])
 	h.Spare = b[7]
 
-	if int(h.Length)+8 != l {
+	if int(h.Length)+8 > l {
 		h.Payload = b[8:]
 		return nil
 	}


### PR DESCRIPTION
Hi @wmnsk !

We are super interested in go-gtp, but have a use-case where we decode gtp messages that are stored at the beginning of a larger buffer. Since we don't know the length of the gtp message in advance, it would be nice if go-gtp would only decode up to the length specified in the gtp header and ignore the remaining bytes. Would you be open to introducing this change?

In the current implementation, `UnmarshalBinary(...)` in header.go checks if the length specified in the header is the same as the buffer size. If not, it will just read the whole buffer:
https://github.com/wmnsk/go-gtp/blob/671898a7c7ec11da9e98c187783a374b02b0054a/gtpv1/message/header.go#L104-L108
We would like it to instead only read up to the length specified in the header (if this doesn't exceed the buffer).

In this PR, we also added some checks to prevent go panicking in case of out-of-bounds access and introduced some constants. The core functional change is exchanging `!=` with `>` in the if-statement.

One thing I am unsure about: Wouldn't it make sense to report an error if the actual length differs from what the header specifies instead of trying to decode whatever is there? Or do I miss the intention of the if-check?

Thanks for looking into this!