### PR TITLE
Fix PCOContainer UnmarshalBinary buffer allocation

### DIFF
--- a/gtpv2/ie/pco.go
+++ b/gtpv2/ie/pco.go
@@ -219,7 +219,8 @@ func (c *PCOContainer) UnmarshalBinary(b []byte) error {
 	c.ID = binary.BigEndian.Uint16(b[0:2])
 	c.Length = b[2]
 
-	if c.Length != 0 && l > 3+int(c.Length) {
+	if c.Length != 0 && l >= 3+int(c.Length) {
+		c.Contents = make([]byte, c.Length)
 		copy(c.Contents, b[3:3+int(c.Length)])
 	}
 


### PR DESCRIPTION
Fixes #135 

Create Contents buffer before copying into it