### PR TITLE
Added pktConn.Close() to client close function

### DIFF
--- a/gtpv1/u-conn.go
+++ b/gtpv1/u-conn.go
@@ -332,6 +332,7 @@ func (u *UPlaneConn) Close() error {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 
+	u.pktConn.Close()
 	close(u.closeCh)
 
 	return nil

--- a/gtpv2/conn.go
+++ b/gtpv2/conn.go
@@ -237,6 +237,7 @@ func (c *Conn) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.pktConn.Close()
 	close(c.closeCh)
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

Hey @wmnsk,
Not sure if this is right, but it looks like the clients never closes the packet connection, leaving ports unusable during runtime.

This PR should fix that.

tests
```
root@docker-desktop:/magma/feg/gateway/services/delme/go-gtp# go test ./...
ok  	github.com/wmnsk/go-gtp	(cached)
?   	github.com/wmnsk/go-gtp/examples/gw-tester/s1mme	[no test files]
?   	github.com/wmnsk/go-gtp/examples/mme	[no test files]
?   	github.com/wmnsk/go-gtp/examples/pgw	[no test files]
?   	github.com/wmnsk/go-gtp/examples/sgw	[no test files]
?   	github.com/wmnsk/go-gtp/gtpv0	[no test files]
ok  	github.com/wmnsk/go-gtp/gtpv0/ie	(cached)
ok  	github.com/wmnsk/go-gtp/gtpv0/message	(cached)
?   	github.com/wmnsk/go-gtp/gtpv0/testutils	[no test files]
ok  	github.com/wmnsk/go-gtp/gtpv1	1.015s
ok  	github.com/wmnsk/go-gtp/gtpv1/ie	(cached)
ok  	github.com/wmnsk/go-gtp/gtpv1/message	(cached)
?   	github.com/wmnsk/go-gtp/gtpv1/testutils	[no test files]
ok  	github.com/wmnsk/go-gtp/gtpv2	0.006s
ok  	github.com/wmnsk/go-gtp/gtpv2/ie	(cached)
ok  	github.com/wmnsk/go-gtp/gtpv2/message	(cached)
?   	github.com/wmnsk/go-gtp/gtpv2/testutils	[no test files]
ok  	github.com/wmnsk/go-gtp/utils	(cached)
```
