### PR TITLE
Script to enable interfaces for testing on MacOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ _This project follows [the Release Policy of Go](https://golang.org/doc/devel/re
 
 Examples works as it is by `go build` and executing commands in the following way.
 
+*Note for MacOs users*: before running any go service, make sure to execute `./mac_local_host_enabler.sh` you will find at [examples/utils](examples/utils)
+
 1. Open four terminals on a machine and start capturing on loopback interface.
 
 2. Start P-GW on terminal #1 and #2
@@ -76,6 +78,14 @@ For the detailed usage of specific version, see README.md under each version's d
 | GTPv0   | [README.md](gtpv0/README.md) |
 | GTPv1   | [README.md](gtpv1/README.md) |
 | GTPv2   | [README.md](gtpv2/README.md) |
+
+And don't forget testing once you are done with your changes 
+```shell-session
+go test ./...
+```
+
+*Note for MacOs users*: the first time you run any test, make sure to execute `./mac_local_host_enabler.sh` you will find at [examples/utils](examples/utils). 
+You will have to run the script again after each reboot
 
 ## Supported Features
 

--- a/examples/utils/mac_local_host_enabler.sh
+++ b/examples/utils/mac_local_host_enabler.sh
@@ -1,0 +1,4 @@
+# This script will enable 127.0.0.1 up to 127.0.0.256 interfaces
+for ((i=2;i<256;i++)) do 
+  sudo ifconfig lo0 alias 127.0.0.$i up
+done 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

go tsets or the MME-SGW-PGW example any ip on the localhost network 127.0.0.x  On MacOs those ip are disabled and they have to be manually enabled

This PR adds a script script to enable all 255 IPs for testing. Also it modifies the main README so other people is aware of that.

Please suggest other location for the script if that is not the correct one


Test on MacOs after running that script and go test
```
╭─ ~/testgit/go-gtp | on go-gtp_add_close_packet_channel_to_close_func *1 ?3                                                                                                                                                                 ✔ | at minikube ○ | at 17:57:03
╰─ go test  ./...
ok  	github.com/wmnsk/go-gtp	(cached)
?   	github.com/wmnsk/go-gtp/examples/gw-tester/s1mme	[no test files]
?   	github.com/wmnsk/go-gtp/examples/mme	[no test files]
?   	github.com/wmnsk/go-gtp/examples/pgw	[no test files]
?   	github.com/wmnsk/go-gtp/examples/sgw	[no test files]
?   	github.com/wmnsk/go-gtp/gtpv0	[no test files]
ok  	github.com/wmnsk/go-gtp/gtpv0/ie	(cached)
ok  	github.com/wmnsk/go-gtp/gtpv0/message	(cached)
?   	github.com/wmnsk/go-gtp/gtpv0/testutils	[no test files]
ok  	github.com/wmnsk/go-gtp/gtpv1	1.250s
ok  	github.com/wmnsk/go-gtp/gtpv1/ie	(cached)
ok  	github.com/wmnsk/go-gtp/gtpv1/message	(cached)
?   	github.com/wmnsk/go-gtp/gtpv1/testutils	[no test files]
ok  	github.com/wmnsk/go-gtp/gtpv2	0.161s
ok  	github.com/wmnsk/go-gtp/gtpv2/ie	(cached)
ok  	github.com/wmnsk/go-gtp/gtpv2/message	(cached)
?   	github.com/wmnsk/go-gtp/gtpv2/testutils	[no test files]
ok  	github.com/wmnsk/go-gtp/utils	(cached)
```
