### PR TITLE
Add OffendingIE parser

### DIFF
--- a/gtpv2/ie/cause.go
+++ b/gtpv2/ie/cause.go
@@ -167,3 +167,25 @@ func (i *IE) IsPDNConnectionIEError() bool {
 	}
 	return false
 }
+
+// OffendingIE returns OffendingIE in *IE if the type of IE matches.
+//
+// Note that the returned IE has no payload (cf. §8.4, TS29.274).
+func (i *IE) OffendingIE() (*IE, error) {
+	if i.Type != Cause {
+		return nil, &InvalidTypeError{Type: i.Type}
+	}
+
+	if len(i.Payload) < 6 {
+		return nil, io.ErrUnexpectedEOF
+	}
+
+	return Parse(i.Payload[2:6])
+}
+
+// MustOffendingIE returns OffendingIE in *IE, ignoring errors.
+// This should only be used if it is assured to have the value.
+func (i *IE) MustOffendingIE() *IE {
+	v, _ := i.OffendingIE()
+	return v
+}

--- a/gtpv2/ie/ie.go
+++ b/gtpv2/ie/ie.go
@@ -251,7 +251,7 @@ func Parse(b []byte) (*IE, error) {
 // UnmarshalBinary sets the values retrieved from byte sequence in GTPv2 IE.
 func (i *IE) UnmarshalBinary(b []byte) error {
 	l := len(b)
-	if l < 5 {
+	if l < 4 {
 		return io.ErrUnexpectedEOF
 	}
 


### PR DESCRIPTION
#165

```go
	c := v2ie.NewCause(gtpv2.CauseAPNCongestion, 0, 0, 0, v2ie.New(v2ie.AccessPointName, 0, nil))

	fmt.Println(c)
	fmt.Println(c.OffendingIE())
```

```
{Cause: {Type: 2, Length: 6, Instance: 0x0, Payload: []byte{0x71, 0x0, 0x47, 0x0, 0x0, 0x0}}}
{AccessPointName: {Type: 71, Length: 0, Instance: 0x0, Payload: []byte{}}} <nil>
```