### PR TITLE
Do not crash when printing the IE in case of nil IE

### DIFF
--- a/gtpv0/ie/ie.go
+++ b/gtpv0/ie/ie.go
@@ -195,6 +195,9 @@ func (i *IE) Name() string {
 
 // String returns the GTPv0 IE values in human readable format.
 func (i *IE) String() string {
+	if i == nil {
+		return "nil"
+	}
 	return fmt.Sprintf("{%s: {Type: %d, Length: %d, Payload: %#v}}",
 		i.Name(),
 		i.Type,

--- a/gtpv1/ie/ie.go
+++ b/gtpv1/ie/ie.go
@@ -305,6 +305,9 @@ func (i *IE) Name() string {
 
 // String returns the GTPv1 IE values in human readable format.
 func (i *IE) String() string {
+	if i == nil {
+		return "nil"
+	}
 	return fmt.Sprintf("{%s: {Type: %d, Length: %d, Payload: %#v}}",
 		i.Name(),
 		i.Type,

--- a/gtpv2/ie/ie.go
+++ b/gtpv2/ie/ie.go
@@ -309,6 +309,9 @@ func (i *IE) Name() string {
 
 // String returns the GTPv2 IE values in human readable format.
 func (i *IE) String() string {
+	if i == nil {
+		return "nil"
+	}
 	return fmt.Sprintf("{%s: {Type: %d, Length: %d, Instance: %#x, Payload: %#v}}",
 		i.Name(),
 		i.Type,


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

For some reason when we build a message manually, some of the IEs are nil (by mistake probably). That causes the prettyprint function implemented here #164 to crash and prevents to debug the content. 

This PR will catch that nil and just print `nil` instead.

This will not prevent crashed due to nil IEs in other functions

A warning log message could be added. in case you want even more visibility in case that happens.  