### PR TITLE
Fix gtp-v1 MCC/MNC decoding

### DIFF
--- a/gtpv1/ie/mcc-mnc.go
+++ b/gtpv1/ie/mcc-mnc.go
@@ -17,12 +17,12 @@ func (i *IE) MCC() (string, error) {
 		if len(i.Payload) < 2 {
 			return "", io.ErrUnexpectedEOF
 		}
-		return utils.SwappedBytesToStr(i.Payload[0:2], false), nil
+		return utils.DecodeMCC(i.Payload[0:2]), nil
 	case UserLocationInformation:
 		if len(i.Payload) < 3 {
 			return "", io.ErrUnexpectedEOF
 		}
-		return utils.SwappedBytesToStr(i.Payload[1:3], false), nil
+		return utils.DecodeMCC(i.Payload[1:3]), nil
 	default:
 		return "", &InvalidTypeError{Type: i.Type}
 	}
@@ -39,15 +39,15 @@ func (i *IE) MustMCC() string {
 func (i *IE) MNC() (string, error) {
 	switch i.Type {
 	case RouteingAreaIdentity:
-		if len(i.Payload) < 2 {
-			return "", io.ErrUnexpectedEOF
-		}
-		return utils.SwappedBytesToStr(i.Payload[1:2], true), nil
-	case UserLocationInformation:
 		if len(i.Payload) < 3 {
 			return "", io.ErrUnexpectedEOF
 		}
-		return utils.SwappedBytesToStr(i.Payload[2:3], true), nil
+		return utils.DecodeMNC(i.Payload[1:3]), nil
+	case UserLocationInformation:
+		if len(i.Payload) < 4 {
+			return "", io.ErrUnexpectedEOF
+		}
+		return utils.DecodeMNC(i.Payload[2:4]), nil
 	default:
 		return "", &InvalidTypeError{Type: i.Type}
 	}

--- a/gtpv1/ie/rai_test.go
+++ b/gtpv1/ie/rai_test.go
@@ -1,0 +1,36 @@
+// Copyright 2019-2021 go-gtp authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package ie
+
+import (
+	"testing"
+)
+
+func TestRouteingAreaIdentity(t *testing.T) {
+	t.Run("Routeing Area Identity", func(t *testing.T) {
+		ie := NewRouteingAreaIdentity("123", "45", 111, 222)
+
+		rac := ie.MustRAC()
+		if rac != 222 {
+			t.Errorf("wrong rac, got %v", rac)
+		}
+
+		lac := ie.MustLAC()
+		if lac != 111 {
+			t.Errorf("wrong lac, got %v", lac)
+		}
+
+		mcc := ie.MustMCC()
+		if mcc != "123" {
+			t.Errorf("wrong mcc, got %v", mcc)
+		}
+
+		mnc := ie.MustMNC()
+		if mnc != "45" {
+			t.Errorf("wrong mnc, got %v", mnc)
+		}
+
+	})
+}

--- a/gtpv1/ie/uli_test.go
+++ b/gtpv1/ie/uli_test.go
@@ -1,0 +1,87 @@
+// Copyright 2019-2021 go-gtp authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package ie
+
+import (
+	"testing"
+)
+
+func TestUserLocationInformationWithCGI(t *testing.T) {
+	t.Run("Test UserLocationInformation with CGI", func(t *testing.T) {
+		ie := NewUserLocationInformationWithCGI("123", "45", 111, 222)
+
+		cgi := ie.MustCGI()
+		if cgi != 222 {
+			t.Errorf("wrong cgi, got %v", cgi)
+		}
+
+		lac := ie.MustLAC()
+		if lac != 111 {
+			t.Errorf("wrong lac, got %v", lac)
+		}
+
+		mcc := ie.MustMCC()
+		if mcc != "123" {
+			t.Errorf("wrong mcc, got %v", mcc)
+		}
+
+		mnc := ie.MustMNC()
+		if mnc != "45" {
+			t.Errorf("wrong mnc, got %v", mnc)
+		}
+	})
+}
+
+func TestUserLocationInformationWithRAI(t *testing.T) {
+	t.Run("Test UserLocationInformation with RAI", func(t *testing.T) {
+		ie := NewUserLocationInformationWithRAI("123", "45", 111, 222)
+
+		rac := ie.MustRAC()
+		if rac != 222 {
+			t.Errorf("wrong rac, got %v", rac)
+		}
+
+		lac := ie.MustLAC()
+		if lac != 111 {
+			t.Errorf("wrong lac, got %v", lac)
+		}
+
+		mcc := ie.MustMCC()
+		if mcc != "123" {
+			t.Errorf("wrong mcc, got %v", mcc)
+		}
+
+		mnc := ie.MustMNC()
+		if mnc != "45" {
+			t.Errorf("wrong mnc, got %v", mnc)
+		}
+	})
+}
+
+func TestUserLocationInformationWithSAI(t *testing.T) {
+	t.Run("Test UserLocationInformation with SAI", func(t *testing.T) {
+		ie := NewUserLocationInformationWithSAI("123", "45", 111, 222)
+
+		sac := ie.MustSAC()
+		if sac != 222 {
+			t.Errorf("wrong sac, got %v", sac)
+		}
+
+		lac := ie.MustLAC()
+		if lac != 111 {
+			t.Errorf("wrong lac, got %v", lac)
+		}
+
+		mcc := ie.MustMCC()
+		if mcc != "123" {
+			t.Errorf("wrong mcc, got %v", mcc)
+		}
+
+		mnc := ie.MustMNC()
+		if mnc != "45" {
+			t.Errorf("wrong mnc, got %v", mnc)
+		}
+	})
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -112,15 +112,25 @@ func EncodePLMN(mcc, mnc string) ([]byte, error) {
 	return b, nil
 }
 
+// DecodeMCC decodes BCD-encoded MCC as it occurs in CGI/SAI/RAI.
+func DecodeMNC(b []byte) string {
+	raw := hex.EncodeToString(b)
+	if raw[0] == 'f' {
+		return string([]byte{raw[3], raw[2]})
+	}
+	return string([]byte{raw[3], raw[2], raw[0]})
+}
+
+// DecodeMNC decodes BCD-encoded MNC as it occurs in CGI/SAI/RAI
+func DecodeMCC(b []byte) string {
+	raw := hex.EncodeToString(b)
+	return string([]byte{raw[1], raw[0], raw[3]})
+}
+
 // DecodePLMN decodes BCD-encoded bytes into MCC and MNC.
 func DecodePLMN(b []byte) (mcc, mnc string, err error) {
-	raw := hex.EncodeToString(b)
-	mcc = string(raw[1]) + string(raw[0]) + string(raw[3])
-	mnc = string(raw[5]) + string(raw[4])
-	if string(raw[2]) != "f" {
-		mnc += string(raw[2])
-	}
-
+	mcc = DecodeMCC(b[0:2])
+	mnc = DecodeMNC(b[1:3])
 	return
 }
 


### PR DESCRIPTION
Sorry this wasn't part of the previous PR, but I only found these bugs at a later point...

This fixes the decoding of MCC and MNC in gtp-v1 IEs. Previously, when decoding them, you would get something like "262f" as MCC, with the "f" not properly removed. The MNC decoder was also not working and didn't cover the case of 3-digit MNCs.
I replaced the `SwappedBytesToStr` call with a dedicated `DecodeM*C` call which works like the decoding of the `PLMN` in gtp-v2.

I also refactored the `PLMN` decoder a bit to make use of these new MCC/MNC decoders, so that there is no code duplication.

The unit tests I added would fail without these fixes with messages like this:
```
--- FAIL: TestNewUserLocationInformationWithCGI (0.00s)
    --- FAIL: TestNewUserLocationInformationWithCGI/Test_NewUserLocationInformationWithCGI (0.00s)
        uli_test.go:27: wrong mcc, got 123f
        uli_test.go:32: wrong mnc, got 3
FAIL
```

**Commit Msg:**
* Add AUTs to verify fix
* Fix RAI and ULI decoding of MCC/MNC
* Refactor DecodePLMN for less code duplication