### PR TITLE
Fix IMEISV decoding in gtp-v1

### DIFF
--- a/gtpv1/ie/imei.go
+++ b/gtpv1/ie/imei.go
@@ -6,6 +6,7 @@ package ie
 
 import (
 	"io"
+	"strings"
 
 	"github.com/wmnsk/go-gtp/utils"
 )
@@ -27,7 +28,8 @@ func (i *IE) IMEISV() (string, error) {
 	if len(i.Payload) == 0 {
 		return "", io.ErrUnexpectedEOF
 	}
-	return utils.SwappedBytesToStr(i.Payload, true), nil
+	str := utils.SwappedBytesToStr(i.Payload, false)
+	return strings.TrimSuffix(str, "f"), nil
 }
 
 // MustIMEISV returns IMEISV in string if type matches.

--- a/gtpv1/ie/imei_test.go
+++ b/gtpv1/ie/imei_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019-2021 go-gtp authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package ie
+
+import "testing"
+
+func TestIE_IMEISV(t *testing.T) {
+	t.Run("Encode/Decode IMEI", func(t *testing.T) {
+		ie := NewIMEISV("123456789012345")
+
+		got := ie.MustIMEISV()
+		if got != "123456789012345" {
+			t.Errorf("wrong IMEI, got: %v", got)
+		}
+	})
+
+	t.Run("Encode/Decode IMEISV", func(t *testing.T) {
+		ie := NewIMEISV("1234567890123456")
+
+		got := ie.MustIMEISV()
+		if got != "1234567890123456" {
+			t.Errorf("wrong IMEISV, got: %v", got)
+		}
+	})
+}


### PR DESCRIPTION
Found another one 😉 😃

This fixes the decoding of the IMEISV IE in gtp-v1. The decoding was correct if it only contained a 15 digit IMEI, but cut off the last digit if it contained a 16 digit IMEISV.
I took the code from the MEI implementation in gtp-v2.

Without the fix, the new unit test fails with:
```
--- FAIL: TestIE_IMEISV (0.00s)
    --- FAIL: TestIE_IMEISV/Encode/Decode_IMEISV (0.00s)
        imei_test.go:24: wrong IMEISV, got: 123456789012345
FAIL
```

**Commit Msg:**
* Add AUT
* No longer cut off the last digit of an IMEISV