### PR TITLE
Fixed wrong flag on SingleRemotePort function

### DIFF
--- a/gtpv2/ie/tft.go
+++ b/gtpv2/ie/tft.go
@@ -592,7 +592,7 @@ func (c *TFTPFComponent) LocalPortRange() (uint16, uint16, error) {
 
 // SingleRemotePort returns SingleRemotePort in uint16 if the type of component matches.
 func (c *TFTPFComponent) SingleRemotePort() (uint16, error) {
-	if c.Type != PFCompSingleLocalPort {
+	if c.Type != PFCompSingleRemotePort {
 		return 0, ErrInvalidType
 	}
 	if len(c.Contents) < 2 {


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

Function SingleRemotePort included a wrong flag pointing to the Local port instead of Remote. This PR fixes that.

Hey @wmnsk, it would be awesome if you could provide a new tag for this fix. Thanks!

