### PR TITLE
Make header parse next extension header type

### DIFF
--- a/gtpv1/message/header.go
+++ b/gtpv1/message/header.go
@@ -15,26 +15,33 @@ const (
 	seqSize = 4
 )
 
+// Next Extension header type
+const (
+	NoMoreExtensionHeaders uint8 = 0x0
+)
+
 // Header is a GTPv1 common header.
 type Header struct {
-	Flags          uint8
-	Type           uint8
-	Length         uint16
-	TEID           uint32
-	SequenceNumber uint16
-	Reserved       uint16
-	Payload        []byte
+	Flags                   uint8
+	Type                    uint8
+	Length                  uint16
+	TEID                    uint32
+	SequenceNumber          uint16
+	Reserved                uint8
+	NextExtensionHeaderType uint8
+	Payload                 []byte
 }
 
 // NewHeader creates a new Header.
 func NewHeader(flags, mtype uint8, teid uint32, seqnum uint16, payload []byte) *Header {
 	h := &Header{
-		Flags:          flags,
-		Type:           mtype,
-		TEID:           teid,
-		SequenceNumber: seqnum,
-		Reserved:       0,
-		Payload:        payload,
+		Flags:                   flags,
+		Type:                    mtype,
+		TEID:                    teid,
+		SequenceNumber:          seqnum,
+		Reserved:                0,
+		NextExtensionHeaderType: NoMoreExtensionHeaders,
+		Payload:                 payload,
 	}
 
 	h.SetLength()
@@ -70,11 +77,15 @@ func (h *Header) MarshalTo(b []byte) error {
 	offset := 8
 	if h.HasSequence() {
 		binary.BigEndian.PutUint16(b[offset:offset+2], h.SequenceNumber)
-		// two bytes of padding before payload.
+	}
+	// one spare byte between SequenceNumber and NextExtensionHeaderType
+	if h.HasExtensionHeader() {
+		h.NextExtensionHeaderType = b[offset+3]
+	}
+	if h.HasSequence() || h.HasExtensionHeader() {
 		offset += 4
 	}
 
-	// two bytes of padding before payload.
 	copy(b[offset:], h.Payload)
 	return nil
 }
@@ -101,12 +112,20 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 
 	h.TEID = binary.BigEndian.Uint32(b[4:8])
 	offset += 4
-	if h.HasSequence() {
+
+	// The optional 4 bytes will append to mandatory GTP header if any one or more S, E flags are set.
+	if h.HasSequence() || h.HasExtensionHeader() {
 		if h.Length < seqSize {
 			return ErrTooShortToParse
 		}
-		h.SequenceNumber = binary.BigEndian.Uint16(b[offset : offset+2])
-		// two bytes of padding before payload.
+		// Sequence number must be interpreted only if the S bit is on
+		if h.HasSequence() {
+			h.SequenceNumber = binary.BigEndian.Uint16(b[offset : offset+2])
+		}
+		// Next Extension Header Type must be interpreted only if the E bit is on.
+		if h.HasExtensionHeader() {
+			h.NextExtensionHeaderType = b[offset+3]
+		}
 		offset += 4
 	}
 
@@ -144,10 +163,20 @@ func (h *Header) SetSequenceNumber(seq uint16) {
 	h.SequenceNumber = seq
 }
 
+// HasExtensionHeader determines whether a GTP Header has extension header inside by checking the flag.
+func (h *Header) HasExtensionHeader() bool {
+	return ((int(h.Flags) >> 2) & 0x1) == 1
+}
+
+// SetSequenceNumber sets the ExtensionHeaderType in Header.
+func (h *Header) SetNextExtensionHeaderType(exhType uint8) {
+	h.NextExtensionHeaderType = exhType
+}
+
 // MarshalLen returns the serial length of Header.
 func (h *Header) MarshalLen() int {
 	l := len(h.Payload) + 8
-	if h.HasSequence() {
+	if h.HasSequence() || h.HasExtensionHeader() {
 		l += 4
 	}
 
@@ -171,12 +200,15 @@ func (h *Header) MessageType() uint8 {
 
 // String returns the GTPv1 header values in human readable format.
 func (h *Header) String() string {
-	return fmt.Sprintf("{Flags: %#x, Type: %#x, Length: %d, TEID: %#08x, SequenceNumber: %#04x, Payload: %#v}",
+	return fmt.Sprintf(
+		"{Flags: %#x, Type: %#x, Length: %d, TEID: %#08x,"+
+			"SequenceNumber: %#04x, ExtensionHeaderType: %#x, Payload: %#v}",
 		h.Flags,
 		h.Type,
 		h.Length,
 		h.TEID,
 		h.SequenceNumber,
+		h.NextExtensionHeaderType,
 		h.Payload,
 	)
 }


### PR DESCRIPTION
Make header parse next extension header type
- Add NextExtensionHeaderType field in header
- Parse NextExtensionHeaderType in UnmarshalBinary if E flag is set
- Set some method to access NextExtensionHeaderType aside for the future