### PR TITLE
Add methods in gtpv1 to set TOS / Traffic Class

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/pascaldekloe/goe v0.1.0
 	github.com/prometheus/client_golang v1.12.1
 	github.com/vishvananda/netlink v1.1.0
+	golang.org/x/net v0.0.0-20210525063256-abc453219eb5
 	google.golang.org/grpc v1.33.2
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/gtpv1/tunnel_linux.go
+++ b/gtpv1/tunnel_linux.go
@@ -40,13 +40,13 @@ const (
 func (u *UPlaneConn) EnableKernelGTP(devname string, role Role) error {
 	if u.pktConn == nil {
 		var err error
-		u.pktConn, err = net.ListenPacket(u.laddr.Network(), u.laddr.String())
+		u.pktConn, err = newPktConnAbstraction(u.laddr)
 		if err != nil {
 			return err
 		}
 	}
 
-	f, err := u.pktConn.(*net.UDPConn).File()
+	f, err := u.pktConn.File()
 	if err != nil {
 		return fmt.Errorf("failed to retrieve file from conn: %w", err)
 	}

--- a/gtpv1/tunnel_linux.go
+++ b/gtpv1/tunnel_linux.go
@@ -40,7 +40,7 @@ const (
 func (u *UPlaneConn) EnableKernelGTP(devname string, role Role) error {
 	if u.pktConn == nil {
 		var err error
-		u.pktConn, err = newPktConnAbstraction(u.laddr)
+		u.pktConn, err = newPktConn(u.laddr)
 		if err != nil {
 			return err
 		}

--- a/gtpv1/u-conn.go
+++ b/gtpv1/u-conn.go
@@ -62,14 +62,14 @@ type pktConn4 struct {
 }
 
 // ReadFrom implements the io.ReaderFrom ReadFrom method.
-func (p pktConn4) ReadFrom(b []byte) (n int, src net.Addr, err error) {
-	n, _, src, err = p.PacketConn.ReadFrom(b)
+func (pkt pktConn4) ReadFrom(b []byte) (n int, src net.Addr, err error) {
+	n, _, src, err = pkt.PacketConn.ReadFrom(b)
 	return n, src, err
 }
 
 // WriteTo implements the PacketConn WriteTo method.
-func (p pktConn4) WriteTo(b []byte, dst net.Addr) (n int, err error) {
-	return p.PacketConn.WriteTo(b, nil, dst)
+func (pkt pktConn4) WriteTo(b []byte, dst net.Addr) (n int, err error) {
+	return pkt.PacketConn.WriteTo(b, nil, dst)
 }
 
 // setDSCPECN sets the DSCP/ECN value used for next writes.
@@ -124,14 +124,14 @@ type pktConn6 struct {
 }
 
 // ReadFrom implements the io.ReaderFrom ReadFrom method.
-func (p pktConn6) ReadFrom(b []byte) (n int, src net.Addr, err error) {
-	n, _, src, err = p.PacketConn.ReadFrom(b)
+func (pkt pktConn6) ReadFrom(b []byte) (n int, src net.Addr, err error) {
+	n, _, src, err = pkt.PacketConn.ReadFrom(b)
 	return n, src, err
 }
 
 // WriteTo implements the PacketConn WriteTo method.
-func (p pktConn6) WriteTo(b []byte, dst net.Addr) (n int, err error) {
-	return p.PacketConn.WriteTo(b, nil, dst)
+func (pkt pktConn6) WriteTo(b []byte, dst net.Addr) (n int, err error) {
+	return pkt.PacketConn.WriteTo(b, nil, dst)
 }
 
 // setDSCPECN sets the DSCP/ECN value used for next writes.


### PR DESCRIPTION
Be able to set DSCP field is required to honor PFCP's Transport Level Marking IE.

As stated in 29.281 section 4.4.1:
```
The DSCP marking as defined by IETF RFC 2474 [26] shall be set:
- based on the QCI, and optionally the ARP priority level, of the associated EPS bearer, as described in
  clause 4.7.3 of 3GPP TS 23.401 [5];
- based on the 5QI and ARP of the associated 5G QoS Flow, as described in clause 5.7.1.6 and clause 5.7.1.7 of
  3GPP TS 23.501 [28].
```