### PR TITLE
Add GTPv1 EndMarker

### DIFF
--- a/gtpv1/message/end-marker.go
+++ b/gtpv1/message/end-marker.go
@@ -1,0 +1,146 @@
+// Copyright 2019-2022 go-gtp authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package message
+
+import (
+	"github.com/wmnsk/go-gtp/gtpv1/ie"
+)
+
+// EndMarker is a EndMarker Header and its IEs above.
+type EndMarker struct {
+	*Header
+	PrivateExtension *ie.IE
+	AdditionalIEs    []*ie.IE
+}
+
+// NewEndMarker creates a new GTP.
+func NewEndMarker(ies ...*ie.IE) *EndMarker {
+	e := &EndMarker{
+		Header: NewHeader(0x30, MsgTypeEndMarker, 0, 0, nil),
+	}
+
+	for _, i := range ies {
+		if i == nil {
+			continue
+		}
+		switch i.Type {
+		case ie.PrivateExtension:
+			e.PrivateExtension = i
+		default:
+			e.AdditionalIEs = append(e.AdditionalIEs, i)
+		}
+	}
+
+	e.SetLength()
+	return e
+}
+
+// Marshal returns the byte sequence generated from a EndMarker.
+func (e *EndMarker) Marshal() ([]byte, error) {
+	b := make([]byte, e.MarshalLen())
+	if err := e.MarshalTo(b); err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}
+
+// MarshalTo puts the byte sequence in the byte array given as b.
+func (e *EndMarker) MarshalTo(b []byte) error {
+	if e.Header.Payload != nil {
+		e.Header.Payload = nil
+	}
+	e.Header.Payload = make([]byte, e.MarshalLen()-e.Header.MarshalLen())
+
+	offset := 0
+	if ie := e.PrivateExtension; ie != nil {
+		if err := ie.MarshalTo(e.Payload[offset:]); err != nil {
+			return err
+		}
+		offset += ie.MarshalLen()
+	}
+
+	for _, ie := range e.AdditionalIEs {
+		if ie == nil {
+			continue
+		}
+		if err := ie.MarshalTo(e.Header.Payload[offset:]); err != nil {
+			return err
+		}
+		offset += ie.MarshalLen()
+	}
+
+	e.Header.SetLength()
+	return e.Header.MarshalTo(b)
+}
+
+// ParseEndMarker decodes a given byte sequence as a EndMarker.
+func ParseEndMarker(b []byte) (*EndMarker, error) {
+	e := &EndMarker{}
+	if err := e.UnmarshalBinary(b); err != nil {
+		return nil, err
+	}
+	return e, nil
+}
+
+// UnmarshalBinary decodes a given byte sequence as a EndMarker.
+func (e *EndMarker) UnmarshalBinary(b []byte) error {
+	var err error
+	e.Header, err = ParseHeader(b)
+	if err != nil {
+		return err
+	}
+
+	ies, err := ie.ParseMultiIEs(e.Header.Payload)
+	if err != nil {
+		return err
+	}
+
+	for _, i := range ies {
+		if i == nil {
+			continue
+		}
+		switch i.Type {
+		case ie.PrivateExtension:
+			e.PrivateExtension = i
+		default:
+			e.AdditionalIEs = append(e.AdditionalIEs, i)
+		}
+	}
+
+	return nil
+}
+
+// MarshalLen returns the serial length of Data.
+func (e *EndMarker) MarshalLen() int {
+	l := e.Header.MarshalLen() - len(e.Header.Payload)
+
+	if ie := e.PrivateExtension; ie != nil {
+		l += ie.MarshalLen()
+	}
+
+	for _, ie := range e.AdditionalIEs {
+		if ie == nil {
+			continue
+		}
+		l += ie.MarshalLen()
+	}
+	return l
+}
+
+// SetLength sets the length in Length field.
+func (e *EndMarker) SetLength() {
+	e.Header.Length = uint16(e.MarshalLen() - 8)
+}
+
+// MessageTypeName returns the name of protocol.
+func (e *EndMarker) MessageTypeName() string {
+	return "End Marker"
+}
+
+// TEID returns the TEID in human-readable string.
+func (e *EndMarker) TEID() uint32 {
+	return e.Header.TEID
+}

--- a/gtpv1/message/end-marker_test.go
+++ b/gtpv1/message/end-marker_test.go
@@ -1,0 +1,33 @@
+// Copyright 2019-2022 go-gtp authors. All rights reserved.
+// Use of this source code is governed by a MIT-style license that can be
+// found in the LICENSE file.
+
+package message_test
+
+import (
+	"testing"
+
+	"github.com/wmnsk/go-gtp/gtpv1/message"
+	"github.com/wmnsk/go-gtp/gtpv1/testutils"
+)
+
+func TestEndMarker(t *testing.T) {
+	cases := []testutils.TestCase{
+		{
+			Description: "Normal",
+			Structured:  message.NewEndMarker(),
+			Serialized: []byte{
+				0x30, 0xfe, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+			},
+		},
+	}
+
+	testutils.Run(t, cases, func(b []byte) (testutils.Serializable, error) {
+		v, err := message.ParseEndMarker(b)
+		if err != nil {
+			return nil, err
+		}
+		v.Payload = nil
+		return v, nil
+	})
+}

--- a/gtpv1/message/header.go
+++ b/gtpv1/message/header.go
@@ -121,7 +121,7 @@ func ParseHeader(b []byte) (*Header, error) {
 // UnmarshalBinary sets the values retrieved from byte sequence in GTPv1 header.
 func (h *Header) UnmarshalBinary(b []byte) error {
 	l := len(b)
-	if l < 11 {
+	if l < 8 {
 		return ErrTooShortToParse
 	}
 	var offset = 4

--- a/gtpv1/message/message.go
+++ b/gtpv1/message/message.go
@@ -80,6 +80,7 @@ const (
 	MsgTypeSGSNContextAcknowledge
 	MsgTypeDataRecordTransferRequest  uint8 = 240
 	MsgTypeDataRecordTransferResponse uint8 = 241
+	MsgTypeEndMarker                  uint8 = 254
 	MsgTypeTPDU                       uint8 = 255
 )
 
@@ -195,6 +196,8 @@ func Parse(b []byte) (Message, error) {
 	case MsgTypeDataRecordTransferResponse:
 		m = &DataRecordTransferRes{}
 	*/
+	case MsgTypeEndMarker:
+		m = &EndMarker{}
 	case MsgTypeTPDU:
 		m = &TPDU{}
 	default:


### PR DESCRIPTION
with the fix for parsing messages without sequence number.

ref. #207