### PR TITLE
Update IPv6() for PDNAddressAllocation

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45
+          version: v1.48
           # Optional: golangci-lint command line arguments.
           args: --issues-exit-code=1 --timeout=3m0s --tests=false --no-config --max-issues-per-linter=4095 --max-same-issues=1023 --disable-all --enable=deadcode --enable=errcheck --enable=gosimple --enable=govet --enable=ineffassign --enable=staticcheck --enable=structcheck --enable=typecheck --enable=unused --enable=varcheck --enable=bodyclose --enable=dogsled --enable=goconst --enable=gofmt --enable=goimports --enable=golint --enable=goprintffuncname --enable=gosec --enable=misspell --enable=nakedret --enable=prealloc --enable=rowserrcheck --enable=stylecheck --enable=unconvert --enable=unparam --enable=exportloopref --enable=gomodguard --enable=asciicheck --enable=errorlint
           # Optional: show only new issues if it's a pull request. The default value is `false`.

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.48
+          version: v1.45
           # Optional: golangci-lint command line arguments.
           args: --issues-exit-code=1 --timeout=3m0s --tests=false --no-config --max-issues-per-linter=4095 --max-same-issues=1023 --disable-all --enable=deadcode --enable=errcheck --enable=gosimple --enable=govet --enable=ineffassign --enable=staticcheck --enable=structcheck --enable=typecheck --enable=unused --enable=varcheck --enable=bodyclose --enable=dogsled --enable=goconst --enable=gofmt --enable=goimports --enable=golint --enable=goprintffuncname --enable=gosec --enable=misspell --enable=nakedret --enable=prealloc --enable=rowserrcheck --enable=stylecheck --enable=unconvert --enable=unparam --enable=exportloopref --enable=gomodguard --enable=asciicheck --enable=errorlint
           # Optional: show only new issues if it's a pull request. The default value is `false`.

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45
+          version: v1.49
           # Optional: golangci-lint command line arguments.
           args: --issues-exit-code=1 --timeout=3m0s --tests=false --no-config --max-issues-per-linter=4095 --max-same-issues=1023 --disable-all --enable=deadcode --enable=errcheck --enable=gosimple --enable=govet --enable=ineffassign --enable=staticcheck --enable=structcheck --enable=typecheck --enable=unused --enable=varcheck --enable=bodyclose --enable=dogsled --enable=goconst --enable=gofmt --enable=goimports --enable=golint --enable=goprintffuncname --enable=gosec --enable=misspell --enable=nakedret --enable=prealloc --enable=rowserrcheck --enable=stylecheck --enable=unconvert --enable=unparam --enable=exportloopref --enable=gomodguard --enable=asciicheck --enable=errorlint
           # Optional: show only new issues if it's a pull request. The default value is `false`.

--- a/gtpv1/logger.go
+++ b/gtpv1/logger.go
@@ -5,7 +5,7 @@
 package gtpv1
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"sync"
@@ -47,7 +47,7 @@ func DisableLogging() {
 	logMu.Lock()
 	defer logMu.Unlock()
 
-	logger.SetOutput(ioutil.Discard)
+	logger.SetOutput(io.Discard)
 }
 
 func setLogger(l *log.Logger) {

--- a/gtpv1/tunnel_linux.go
+++ b/gtpv1/tunnel_linux.go
@@ -29,8 +29,8 @@ const (
 // After enabled, users should add tunnels by AddTunnel func, and also add appropriate
 // routing entries. For handling downlink traffic on P-GW, for example;
 //
-//	ip route add <UE's IP> dev <devname> table <table ID>
-//	ip rule add from <SGi side of I/F> lookup <table ID>
+// ip route add <UE's IP> dev <devname> table <table ID>
+// ip rule add from <SGi side of I/F> lookup <table ID>
 //
 // This let the traffic from SGi side of network I/F to be forwarded to GTP device,
 // and if the UE's IP is known to Kernel GTP-U(by AddTunnel), it is encapsulated and

--- a/gtpv1/tunnel_linux.go
+++ b/gtpv1/tunnel_linux.go
@@ -24,18 +24,18 @@ const (
 // EnableKernelGTP enables Linux Kernel GTP-U.
 // Note that this removes all the existing userland tunnels, and cannot be disabled while
 // the program is working (at least at this moment).
-//
+
 // Using Kernel GTP-U is much more performant than userland, but requires root privilege.
 // After enabled, users should add tunnels by AddTunnel func, and also add appropriate
 // routing entries. For handling downlink traffic on P-GW, for example;
-//
+
 //  ip route add <UE's IP> dev <devname> table <table ID>
 //  ip rule add from <SGi side of I/F> lookup <table ID>
-//
+
 // This let the traffic from SGi side of network I/F to be forwarded to GTP device,
 // and if the UE's IP is known to Kernel GTP-U(by AddTunnel), it is encapsulated and
 // forwarded to the peer(S-GW, in this case).
-//
+
 // Please see the examples/gw-tester for how each node handles routing from the program.
 func (u *UPlaneConn) EnableKernelGTP(devname string, role Role) error {
 	if u.pktConn == nil {

--- a/gtpv1/tunnel_linux.go
+++ b/gtpv1/tunnel_linux.go
@@ -29,8 +29,8 @@ const (
 // After enabled, users should add tunnels by AddTunnel func, and also add appropriate
 // routing entries. For handling downlink traffic on P-GW, for example;
 //
-// ip route add <UE's IP> dev <devname> table <table ID>
-// ip rule add from <SGi side of I/F> lookup <table ID>
+//	ip route add <UE's IP> dev <devname> table <table ID>
+//	ip rule add from <SGi side of I/F> lookup <table ID>
 //
 // This let the traffic from SGi side of network I/F to be forwarded to GTP device,
 // and if the UE's IP is known to Kernel GTP-U(by AddTunnel), it is encapsulated and

--- a/gtpv1/tunnel_linux.go
+++ b/gtpv1/tunnel_linux.go
@@ -24,18 +24,18 @@ const (
 // EnableKernelGTP enables Linux Kernel GTP-U.
 // Note that this removes all the existing userland tunnels, and cannot be disabled while
 // the program is working (at least at this moment).
-
+//
 // Using Kernel GTP-U is much more performant than userland, but requires root privilege.
 // After enabled, users should add tunnels by AddTunnel func, and also add appropriate
 // routing entries. For handling downlink traffic on P-GW, for example;
-
-//  ip route add <UE's IP> dev <devname> table <table ID>
-//  ip rule add from <SGi side of I/F> lookup <table ID>
-
+//
+//	ip route add <UE's IP> dev <devname> table <table ID>
+//	ip rule add from <SGi side of I/F> lookup <table ID>
+//
 // This let the traffic from SGi side of network I/F to be forwarded to GTP device,
 // and if the UE's IP is known to Kernel GTP-U(by AddTunnel), it is encapsulated and
 // forwarded to the peer(S-GW, in this case).
-
+//
 // Please see the examples/gw-tester for how each node handles routing from the program.
 func (u *UPlaneConn) EnableKernelGTP(devname string, role Role) error {
 	if u.pktConn == nil {

--- a/gtpv2/conn.go
+++ b/gtpv2/conn.go
@@ -335,12 +335,12 @@ func (c *Conn) handleMessage(senderAddr net.Addr, msg message.Message) error {
 // EnableValidation turns on automatic validation of incoming message.
 // This is expected to be used only after DisableValidation() is used, as the validation
 // is enabled by default.
-
+//
 // Conn checks if;
 //
-//  GTP Version is 2
-//  TEID is known to Conn
-
+//	GTP Version is 2
+//	TEID is known to Conn
+//
 // Even the validation is failed, it does not return error to user. Instead, it just logs
 // and discards the packets so that the HandlerFunc won't get the invalid message.
 // Extra validations should be done in HandlerFunc.

--- a/gtpv2/conn.go
+++ b/gtpv2/conn.go
@@ -335,12 +335,12 @@ func (c *Conn) handleMessage(senderAddr net.Addr, msg message.Message) error {
 // EnableValidation turns on automatic validation of incoming message.
 // This is expected to be used only after DisableValidation() is used, as the validation
 // is enabled by default.
-//
+
 // Conn checks if;
 //
 //  GTP Version is 2
 //  TEID is known to Conn
-//
+
 // Even the validation is failed, it does not return error to user. Instead, it just logs
 // and discards the packets so that the HandlerFunc won't get the invalid message.
 // Extra validations should be done in HandlerFunc.

--- a/gtpv2/conn.go
+++ b/gtpv2/conn.go
@@ -338,8 +338,8 @@ func (c *Conn) handleMessage(senderAddr net.Addr, msg message.Message) error {
 //
 // Conn checks if;
 //
-// GTP Version is 2
-// TEID is known to Conn
+//	GTP Version is 2
+//	TEID is known to Conn
 //
 // Even the validation is failed, it does not return error to user. Instead, it just logs
 // and discards the packets so that the HandlerFunc won't get the invalid message.

--- a/gtpv2/conn.go
+++ b/gtpv2/conn.go
@@ -338,8 +338,8 @@ func (c *Conn) handleMessage(senderAddr net.Addr, msg message.Message) error {
 //
 // Conn checks if;
 //
-//	GTP Version is 2
-//	TEID is known to Conn
+// GTP Version is 2
+// TEID is known to Conn
 //
 // Even the validation is failed, it does not return error to user. Instead, it just logs
 // and discards the packets so that the HandlerFunc won't get the invalid message.

--- a/gtpv2/ie/ip-addr.go
+++ b/gtpv2/ie/ip-addr.go
@@ -165,13 +165,22 @@ func (i *IE) IPv6() (net.IP, error) {
 	}
 
 	switch i.Type {
-	case IPAddress, PDNAddressAllocation, S103PDNDataForwardingInfo, S1UDataForwarding:
+	case IPAddress, S103PDNDataForwardingInfo, S1UDataForwarding:
 		ip, err := i.IP()
 		if err != nil {
 			return nil, err
 		}
 
 		if v := ip.To16(); v != nil {
+			return v, nil
+		}
+		return nil, ErrIEValueNotFound
+	case PDNAddressAllocation:
+		paa, err := ParsePDNAddressAllocationFields(i.Payload)
+		if err != nil {
+			return nil, err
+		}
+		if v := paa.IPv6Address.To16(); v != nil {
 			return v, nil
 		}
 		return nil, ErrIEValueNotFound

--- a/gtpv2/ie/ip-addr_test.go
+++ b/gtpv2/ie/ip-addr_test.go
@@ -6,90 +6,77 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/wmnsk/go-gtp/gtpv2"
 	"github.com/wmnsk/go-gtp/gtpv2/ie"
 )
 
 func TestPDNAddressAllocationIP(t *testing.T) {
-
-	type IPAddr struct {
-		ip  net.IP
-		err error
-	}
 	cases := []struct {
 		description string
 		paa         *ie.IE
-		ipv4        IPAddr
-		ipv6        IPAddr
+		pdnType     uint8
+		ipv4        net.IP
+		ipv6        net.IP
 	}{
 		{
 			"PDNType IPv4",
 			ie.NewPDNAddressAllocation("1.2.3.4"),
-			IPAddr{
-				net.ParseIP("1.2.3.4"),
-				nil,
-			},
-			IPAddr{
-				nil,
-				ie.ErrIEValueNotFound,
-			},
+			gtpv2.PDNTypeIPv4,
+			net.ParseIP("1.2.3.4"),
+			nil,
 		},
 		{
 			"PDNType IPv6",
 			ie.NewPDNAddressAllocation("::1"),
-			IPAddr{
-				nil,
-				ie.ErrIEValueNotFound,
-			},
-			IPAddr{
-				net.ParseIP("::1"),
-				nil,
-			},
+			gtpv2.PDNTypeIPv6,
+			nil,
+			net.ParseIP("::1"),
 		},
 		{
 			"PDNType IPv4v6",
-			ie.NewPDNAddressAllocationDual("1.2.3.4", "::1", uint8(64)),
-			IPAddr{
-				net.ParseIP("1.2.3.4"),
-				nil,
-			},
-			IPAddr{
-				net.ParseIP("::1"),
-				nil,
-			},
+			ie.NewPDNAddressAllocationDual("1.2.3.4", "::1", 64),
+			gtpv2.PDNTypeIPv4v6,
+			net.ParseIP("1.2.3.4"),
+			net.ParseIP("::1"),
 		},
 		{
 			"PDNType NonIP",
 			ie.NewPDNAddressAllocation(""),
-			IPAddr{
-				nil,
-				io.ErrUnexpectedEOF,
-			},
-			IPAddr{
-				nil,
-				io.ErrUnexpectedEOF,
-			},
+			gtpv2.PDNTypeNonIP,
+			nil,
+			nil,
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-
-			ipv4, err := c.paa.IPv4()
-			if diff := cmp.Diff(ipv4, c.ipv4.ip); diff != "" {
+			pdnType := c.paa.MustPDNType()
+			if diff := cmp.Diff(pdnType, c.pdnType); diff != "" {
 				t.Error(diff)
 			}
-			if err != c.ipv4.err {
-				t.Errorf("IPv4() error = %v, want %v", err, c.ipv4.err)
-			}
 
-			ipv6, err := c.paa.IPv6()
-			if diff := cmp.Diff(ipv6, c.ipv6.ip); diff != "" {
+			ipv4, _ := c.paa.IPv4()
+			if diff := cmp.Diff(ipv4, c.ipv4); diff != "" {
 				t.Error(diff)
 			}
-			if err != c.ipv6.err {
-				t.Errorf("IPv6() error = %v, want %v", err, c.ipv6.err)
+
+			ipv6, _ := c.paa.IPv6()
+			if diff := cmp.Diff(ipv6, c.ipv6); diff != "" {
+				t.Error(diff)
 			}
 
+			ip, err := c.paa.IP()
+			if err == nil {
+				v := ipv4
+				if pdnType == gtpv2.PDNTypeIPv6 {
+					v = ipv6
+				}
+				if diff := cmp.Diff(ip, v); diff != "" {
+					t.Error(diff)
+				}
+			} else if err != io.ErrUnexpectedEOF {
+				t.Error(err)
+			}
 		})
 	}
 }

--- a/gtpv2/ie/ip-addr_test.go
+++ b/gtpv2/ie/ip-addr_test.go
@@ -1,73 +1,93 @@
 package ie_test
 
 import (
+	"io"
 	"net"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/wmnsk/go-gtp/gtpv2"
 	"github.com/wmnsk/go-gtp/gtpv2/ie"
 )
 
 func TestPDNAddressAllocationIP(t *testing.T) {
+
+	type IPAddr struct {
+		ip  net.IP
+		err error
+	}
 	cases := []struct {
 		description string
 		paa         *ie.IE
-		ipv4        net.IP
-		ipv6        net.IP
+		ipv4        IPAddr
+		ipv6        IPAddr
 	}{
 		{
 			"PDNType IPv4",
 			ie.NewPDNAddressAllocation("1.2.3.4"),
-			net.ParseIP("1.2.3.4"),
-			nil,
+			IPAddr{
+				net.ParseIP("1.2.3.4"),
+				nil,
+			},
+			IPAddr{
+				nil,
+				ie.ErrIEValueNotFound,
+			},
 		},
 		{
 			"PDNType IPv6",
 			ie.NewPDNAddressAllocation("::1"),
-			nil,
-			net.ParseIP("::1"),
+			IPAddr{
+				nil,
+				ie.ErrIEValueNotFound,
+			},
+			IPAddr{
+				net.ParseIP("::1"),
+				nil,
+			},
 		},
 		{
 			"PDNType IPv4v6",
 			ie.NewPDNAddressAllocationDual("1.2.3.4", "::1", uint8(64)),
-			net.ParseIP("1.2.3.4"),
-			net.ParseIP("::1"),
+			IPAddr{
+				net.ParseIP("1.2.3.4"),
+				nil,
+			},
+			IPAddr{
+				net.ParseIP("::1"),
+				nil,
+			},
 		},
 		{
 			"PDNType NonIP",
 			ie.NewPDNAddressAllocation(""),
-			nil,
-			nil,
+			IPAddr{
+				nil,
+				io.ErrUnexpectedEOF,
+			},
+			IPAddr{
+				nil,
+				io.ErrUnexpectedEOF,
+			},
 		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
-			pdnType := c.paa.MustPDNType()
-			if pdnType == gtpv2.PDNTypeIPv4 || pdnType == gtpv2.PDNTypeIPv4v6 {
-				ipv4, err := c.paa.IPv4()
-				if err != nil {
-					t.Fatal(err)
-				}
-				if diff := cmp.Diff(ipv4, c.ipv4); diff != "" {
-					t.Error(diff)
-				}
+
+			ipv4, err := c.paa.IPv4()
+			if diff := cmp.Diff(ipv4, c.ipv4.ip); diff != "" {
+				t.Error(diff)
 			}
-			if pdnType == gtpv2.PDNTypeIPv6 || pdnType == gtpv2.PDNTypeIPv4v6 {
-				ipv6, err := c.paa.IPv6()
-				if err != nil {
-					t.Fatal(err)
-				}
-				if diff := cmp.Diff(ipv6, c.ipv6); diff != "" {
-					t.Error(diff)
-				}
+			if err != c.ipv4.err {
+				t.Errorf("IPv4() error = %v, want %v", err, c.ipv4.err)
 			}
-			if pdnType == gtpv2.PDNTypeNonIP {
-				_, err := c.paa.IP()
-				if err == ie.ErrIEValueNotFound {
-					t.Error(err)
-				}
+
+			ipv6, err := c.paa.IPv6()
+			if diff := cmp.Diff(ipv6, c.ipv6.ip); diff != "" {
+				t.Error(diff)
+			}
+			if err != c.ipv6.err {
+				t.Errorf("IPv6() error = %v, want %v", err, c.ipv6.err)
 			}
 
 		})

--- a/gtpv2/ie/ip-addr_test.go
+++ b/gtpv2/ie/ip-addr_test.go
@@ -1,0 +1,75 @@
+package ie_test
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/wmnsk/go-gtp/gtpv2"
+	"github.com/wmnsk/go-gtp/gtpv2/ie"
+)
+
+func TestPDNAddressAllocationIP(t *testing.T) {
+	cases := []struct {
+		description string
+		paa         *ie.IE
+		ipv4        net.IP
+		ipv6        net.IP
+	}{
+		{
+			"PDNType IPv4",
+			ie.NewPDNAddressAllocation("1.2.3.4"),
+			net.ParseIP("1.2.3.4"),
+			nil,
+		},
+		{
+			"PDNType IPv6",
+			ie.NewPDNAddressAllocation("::1"),
+			nil,
+			net.ParseIP("::1"),
+		},
+		{
+			"PDNType IPv4v6",
+			ie.NewPDNAddressAllocationDual("1.2.3.4", "::1", uint8(64)),
+			net.ParseIP("1.2.3.4"),
+			net.ParseIP("::1"),
+		},
+		{
+			"PDNType NonIP",
+			ie.NewPDNAddressAllocation(""),
+			nil,
+			nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			pdnType := c.paa.MustPDNType()
+			if pdnType == gtpv2.PDNTypeIPv4 || pdnType == gtpv2.PDNTypeIPv4v6 {
+				ipv4, err := c.paa.IPv4()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if diff := cmp.Diff(ipv4, c.ipv4); diff != "" {
+					t.Error(diff)
+				}
+			}
+			if pdnType == gtpv2.PDNTypeIPv6 || pdnType == gtpv2.PDNTypeIPv4v6 {
+				ipv6, err := c.paa.IPv6()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if diff := cmp.Diff(ipv6, c.ipv6); diff != "" {
+					t.Error(diff)
+				}
+			}
+			if pdnType == gtpv2.PDNTypeNonIP {
+				_, err := c.paa.IP()
+				if err == ie.ErrIEValueNotFound {
+					t.Error(err)
+				}
+			}
+
+		})
+	}
+}

--- a/gtpv2/ie/pco.go
+++ b/gtpv2/ie/pco.go
@@ -145,6 +145,7 @@ func (f *ProtocolConfigurationOptionsFields) MarshalLen() int {
 // ProtocolIdentifier definitions.
 //
 // [Table 10.5.154/3GPP TS 24.008]
+//
 // At least the following protocol identifiers (as defined in RFC 3232 [103]) shall be
 // supported in this version of the protocol:
 // - C021H (LCP);

--- a/gtpv2/ie/pco.go
+++ b/gtpv2/ie/pco.go
@@ -145,13 +145,12 @@ func (f *ProtocolConfigurationOptionsFields) MarshalLen() int {
 // ProtocolIdentifier definitions.
 //
 // [Table 10.5.154/3GPP TS 24.008]
-//
 // At least the following protocol identifiers (as defined in RFC 3232 [103]) shall be
 // supported in this version of the protocol:
-//  - C021H (LCP);
-//  - C023H (PAP);
-//  - C223H (CHAP); and
-//  - 8021H (IPCP).
+// - C021H (LCP);
+// - C023H (PAP);
+// - C223H (CHAP); and
+// - 8021H (IPCP).
 const (
 	PCOProtocolIdentifierLCP  uint16 = 0xc021
 	PCOProtocolIdentifierPAP  uint16 = 0xc023

--- a/gtpv2/logger.go
+++ b/gtpv2/logger.go
@@ -5,7 +5,7 @@
 package gtpv2
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"sync"
@@ -47,7 +47,7 @@ func DisableLogging() {
 	logMu.Lock()
 	defer logMu.Unlock()
 
-	logger.SetOutput(ioutil.Discard)
+	logger.SetOutput(io.Discard)
 }
 
 func setLogger(l *log.Logger) {


### PR DESCRIPTION
If request contains PDNType ipv46(this means that PAA contains two addresses at the same time), there is a need to check the IP addresses. By default IP() return ipv4 address. IPv6() was updated and now return ipv6 address or err if address not present.