### PR TITLE
Bugfix: Do not panic when decoding corrupted headers

### DIFF
--- a/gtpv1/message/extension-header.go
+++ b/gtpv1/message/extension-header.go
@@ -108,10 +108,6 @@ func ParseMultiExtensionHeaders(b []byte) ([]*ExtensionHeader, error) {
 	var ehs []*ExtensionHeader
 	next := ExtHeaderTypeNoMoreExtensionHeaders
 	for {
-		if len(b) == 0 {
-			break
-		}
-
 		eh, err := ParseExtensionHeader(b)
 		if err != nil {
 			return nil, err

--- a/gtpv1/message/extension-header.go
+++ b/gtpv1/message/extension-header.go
@@ -92,6 +92,9 @@ func (e *ExtensionHeader) UnmarshalBinary(b []byte) error {
 	}
 
 	e.Length = b[0]
+	if e.Length == 0 {
+		return ErrInvalidLength
+	}
 	offset := int(e.Length)*4 - 1
 	if l < offset+1 {
 		return ErrTooShortToParse

--- a/gtpv1/message/header.go
+++ b/gtpv1/message/header.go
@@ -166,6 +166,9 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 		}
 	}
 
+	if l < int(8+h.Length) {
+		return ErrTooShortToParse
+	}
 	h.Payload = b[offset : 8+h.Length]
 	return nil
 }

--- a/gtpv1/message/header.go
+++ b/gtpv1/message/header.go
@@ -132,6 +132,10 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 	h.TEID = binary.BigEndian.Uint32(b[4:8])
 	offset += 4
 
+	if l < int(h.Length)+8 {
+		return ErrTooShortToParse
+	}
+
 	s, pn, e := h.HasSequence(), h.HasNPDUNumber(), h.HasExtensionHeader()
 	// The optional 4 bytes will append to mandatory GTP header if any one or more S, E flags are set.
 	if s || pn || e {
@@ -166,8 +170,8 @@ func (h *Header) UnmarshalBinary(b []byte) error {
 		}
 	}
 
-	if l < int(8+h.Length) {
-		return ErrTooShortToParse
+	if offset > int(h.Length)+8 {
+		return ErrInvalidLength
 	}
 	h.Payload = b[offset : 8+h.Length]
 	return nil

--- a/gtpv1/message/header_test.go
+++ b/gtpv1/message/header_test.go
@@ -252,3 +252,16 @@ func TestHeaderErrorDetection(t *testing.T) {
 		})
 	}
 }
+
+func FuzzHeader(f *testing.F) {
+	f.Add([]byte("10000000"))
+	f.Add([]byte("70\x00\x0400000000\x000"))
+	f.Add([]byte("70\x00\x0400000000\x0100\x00"))
+
+	f.Fuzz(func(t *testing.T, pkt []byte) {
+		header, err := message.ParseHeader(pkt)
+		if header == nil && err == nil {
+			t.Errorf("nil without error")
+		}
+	})
+}

--- a/gtpv1/message/header_test.go
+++ b/gtpv1/message/header_test.go
@@ -228,6 +228,19 @@ func TestHeaderErrorDetection(t *testing.T) {
 			},
 			Error: message.ErrTooShortToParse, // Expect too short to parse error, as missing ext header has length 0
 		},
+		{
+			Description: "IncorrectLength",
+			Serialized: []byte{
+				0b00110010, // Version (3 bits), PT, (*), E, S, PN
+				0x03,       // Message Type
+				0x30, 0x33, // Length (2 octets)
+				0x00, 0x00, 0x00, 0x00, // TEID (4 octets)
+				0x00, 0x06, // Seqence Number (2 octets)
+				0xff,       // N-PDU Number (to be ignored)
+				0b00000000, // Next Extension Header Type
+			},
+			Error: message.ErrTooShortToParse, // Expect too short to parse error, as missing ext header has length 0
+		},
 	}
 
 	for _, c := range cases {

--- a/gtpv1/message/header_test.go
+++ b/gtpv1/message/header_test.go
@@ -207,3 +207,35 @@ func TestHeader(t *testing.T) {
 		return v, nil
 	})
 }
+
+func TestHeaderErrorDetection(t *testing.T) {
+	cases := []struct {
+		Description string
+		Serialized  []byte
+		Error       error
+	}{
+		{
+			Description: "ExtFlagSetButMissingExt",
+			Serialized: []byte{
+				0b00110110, // Version (3 bits), PT, (*), E, S, PN
+				0x03,       // Message Type
+				0x00, 0x04, // Length (2 octets)
+				0x00, 0x00, 0x00, 0x00, // TEID (4 octets)
+				0x00, 0x06, // Seqence Number (2 octets)
+				0xff,       // N-PDU Number (to be ignored)
+				0b11000001, // Next Extension Header Type
+				// Extension Header would go here, but is missing
+			},
+			Error: message.ErrTooShortToParse, // Expect too short to parse error, as missing ext header has length 0
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.Description, func(t *testing.T) {
+			_, err := message.ParseHeader(c.Serialized)
+			if err != c.Error {
+				t.Fatalf("got '%v' want '%v'", err, c.Error)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes two issues related to decoding gtpv1 headers that contain inconsistent/corrupted data. It also adds unit tests to check that these headers are handled correctly. Each fix has its own commit.

### Issue 1: Missing extension header

Sending a packet with the extension header flag set, but without the actual extension header data, would panic with an "index out of range" error. Running the new tests without the fix would give:

<details>
  <summary>Panic + Stacktrace</summary>

```
$ go test gtpv1/message/header_test.go
--- FAIL: TestHeaderErrorDetection (0.00s)
    --- FAIL: TestHeaderErrorDetection/ExtFlagSetButMissingExt (0.00s)
panic: runtime error: index out of range [0] with length 0 [recovered]
        panic: runtime error: index out of range [0] with length 0

goroutine 56 [running]:
testing.tRunner.func1.2({0x53e680, 0xc00015c0f0})
        /usr/lib/golang/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
        /usr/lib/golang/src/testing/testing.go:1392 +0x39f
panic({0x53e680, 0xc00015c0f0})
        /usr/lib/golang/src/runtime/panic.go:838 +0x207
github.com/wmnsk/go-gtp/gtpv1/message.(*Header).UnmarshalBinary(0xc000156b80, {0xc00012ec90, 0x61e330?, 0xc})
        /home/useracnt/code/go-gtp/gtpv1/message/header.go:162 +0x27c
github.com/wmnsk/go-gtp/gtpv1/message.ParseHeader({0xc00012ec90, 0xc, 0xc})
        /home/useracnt/code/go-gtp/gtpv1/message/header.go:115 +0x48
command-line-arguments_test.TestHeaderErrorDetection.func1(0xc000171ba0)
        /home/useracnt/code/go-gtp/gtpv1/message/header_test.go:235 +0x36
testing.tRunner(0xc000171ba0, 0xc000112fd0)
        /usr/lib/golang/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
        /usr/lib/golang/src/testing/testing.go:1486 +0x35f
FAIL    command-line-arguments  0.004s
FAIL
```

</details>

The underlying issue was that if no extension headers were found and if no error was reported during unmarshal, the following line would panic:
```go
h.ExtensionHeaders[0].Type = h.NextExtensionHeaderType
```

The proposed fix is to no longer silently break and return if an extension header is expected but the remaining pkt length is zero.


### Issue 2: An incorrect (too long) length in the header causes a panic

When extracting the payload from the remaining packet bytes, the remaining length is not checked and an out-of-bounds panic will result if there is not enough data.

Here is the panic+stacktrace resulting from the 2nd unit test before the fix:

<details>
  <summary>Panic + Stacktrace</summary>

```
$ go test gtpv1/message/header_test.go
--- FAIL: TestHeaderErrorDetection (0.00s)
    --- FAIL: TestHeaderErrorDetection/IncorrectLength (0.00s)
panic: runtime error: slice bounds out of range [:12347] with capacity 12 [recovered]
        panic: runtime error: slice bounds out of range [:12347] with capacity 12

goroutine 45 [running]:
testing.tRunner.func1.2({0x53e680, 0xc00001a288})
        /usr/lib/golang/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
        /usr/lib/golang/src/testing/testing.go:1392 +0x39f
panic({0x53e680, 0xc00001a288})
        /usr/lib/golang/src/runtime/panic.go:838 +0x207
github.com/wmnsk/go-gtp/gtpv1/message.(*Header).UnmarshalBinary(0x4b9a40?, {0xc000016db0?, 0x634520?, 0x4b9a73?})
        /home/useracnt/code/go-gtp/gtpv1/message/header.go:169 +0x237
github.com/wmnsk/go-gtp/gtpv1/message.ParseHeader({0xc000016db0, 0xc, 0xc})
        /home/useracnt/code/go-gtp/gtpv1/message/header.go:115 +0x48
command-line-arguments_test.TestHeaderErrorDetection.func1(0xc00014d1e0)
        /home/useracnt/code/go-gtp/gtpv1/message/header_test.go:248 +0x3a
testing.tRunner(0xc00014d1e0, 0xc000067010)
        /usr/lib/golang/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
        /usr/lib/golang/src/testing/testing.go:1486 +0x35f
FAIL    command-line-arguments  0.004s
FAIL
```

</details>

The offending line in this case was:

```
h.Payload = b[offset : 8+h.Length]
```

### Issue 3: Added a fuzzing test and found a couple more issues about unchecked slice access

(see 3rd commit)
