### PR TITLE
[gtpv2] Fix the overflow value for the sequence number (#265)

### DIFF
--- a/gtpv2/conn.go
+++ b/gtpv2/conn.go
@@ -401,7 +401,7 @@ func (c *Conn) IncSequence() uint32 {
 	c.sequence++
 
 	// SequenceNumber is 3-octet long
-	if c.sequence > 0xffffff {
+	if c.sequence > 0x7fffff {
 		c.sequence = 0
 	}
 


### PR DESCRIPTION
Make the sequence number counter wrap around to zero on reaching `0x800000` instead of `0x1000000`.  The explanation why this value should be used can be found in 3GPP TS 29.274, section 7.6 ("Reliable Delivery of Signalling Messages"), where it is mentioned that sequence numbers with their most significant bit set to 1 should be used only for Command messages and for requests which were triggered by Command messages, as well as for Triggered Reply messages, and *not* for requests which were not triggered by a Command message (i.e. Initial Request messages).  It is therefore assumed that if the sequence number counter is initialized with zero, it is supposed to be used when sending Initial Request messages only.  That's why its value becoming `0x800000` (and being incremented further) would in practice change the type of the message and the way it's supposed to be handled, which is incorrect behavior.