### PR TITLE
fix: add lock at WriteTo

### DIFF
--- a/gtpv1/u-conn.go
+++ b/gtpv1/u-conn.go
@@ -476,6 +476,8 @@ func (u *UPlaneConn) ReadFromGTP(p []byte) (n int, addr net.Addr, teid uint32, e
 // see SetDeadline and SetWriteDeadline.
 // On packet-oriented connections, write timeouts are rare.
 func (u *UPlaneConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
 	return u.pktConn.WriteToWithDSCPECN(p, addr, 0)
 }
 


### PR DESCRIPTION
In my situation, I have two goroutines: one uses `UPlaneConn.ListenAndServe` to receive packets, and the other uses `UPlaneConn.WriteTo` to send packets. It reports a race condition warning when I execute the Go program with the `-race` option.

```
func (u *UPlaneConn) ListenAndServe(ctx context.Context) error {
	if u.pktConn == nil {
		var err error
		u.mu.Lock()
		u.pktConn, err = newPktConn(u.laddr)   // <- race here
		u.mu.Unlock()
		if err != nil {
			return err
		}
	}
	return u.listenAndServe(ctx)
}
```

```
func (u *UPlaneConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
	return u.pktConn.WriteToWithDSCPECN(p, addr, 0)  // <- race here
}
```