### PR TITLE
fix: GTP-U V1 echo request should not contain recovery

### DIFF
--- a/gtpv1/u-conn.go
+++ b/gtpv1/u-conn.go
@@ -602,7 +602,7 @@ func (u *UPlaneConn) handleMessage(senderAddr net.Addr, msg message.Message) err
 
 // EchoRequest sends a EchoRequest.
 func (u *UPlaneConn) EchoRequest(raddr net.Addr) error {
-	b, err := message.NewEchoRequest(0, ie.NewRecovery(0)).Marshal()
+	b, err := message.NewEchoRequest(0).Marshal()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
According to [TS 29.281](https://portal.3gpp.org/desktopmodules/Specifications/SpecificationDetails.aspx?specificationId=1699), section 7.2.1, an Echo Request message should not contain a Recovery IE. This is the case for Release 15-18.